### PR TITLE
Resource deploy status states

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -208,10 +208,10 @@ module KubernetesDeploy
         next if matching_resources.empty?
         deploy_resources(matching_resources, verify: true, record_summary: false)
 
-        unsucceesful_resources = resources.reject { |r| r.deploy_status == "succeeded" }
+        unsucceesful_resources = matching_resources.reject { |r| r.deploy_status == "succeeded" }
         fail_count = unsucceesful_resources.length
         if fail_count > 0
-          KubernetesDeploy::Concurrency.split_across_threads(failed_resources) do |r|
+          KubernetesDeploy::Concurrency.split_across_threads(unsucceesful_resources) do |r|
             r.sync_debug_info(@sync_mediator.kubectl)
           end
           unsucceesful_resources.each { |r| @logger.summary.add_paragraph(r.debug_message) }

--- a/lib/kubernetes-deploy/kubernetes_resource.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource.rb
@@ -26,7 +26,7 @@ module KubernetesDeploy
       MSG
 
     TIMEOUT_OVERRIDE_ANNOTATION = "kubernetes-deploy.shopify.io/timeout-override"
-    DEPLOY_STATUSES = %w(succeeded failure timeout started unknown)
+    DEPLOY_STATUSES = %w(succeeded failed timed_out started unknown)
 
     class << self
       def build(namespace:, context:, definition:, logger:, statsd_tags:)

--- a/lib/kubernetes-deploy/kubernetes_resource/bucket.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/bucket.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Bucket < KubernetesResource
+    def status
+      exists? ? "Available" : "Unknown"
+    end
+
+    def deploy_method
+      :replace
+    end
+
+    private
+
     def deploy_succeeded?
       return false unless deploy_started?
 
@@ -9,18 +19,6 @@ module KubernetesDeploy
         @success_assumption_warning_shown = true
       end
       true
-    end
-
-    def status
-      exists? ? "Available" : "Unknown"
-    end
-
-    def deploy_failed?
-      false
-    end
-
-    def deploy_method
-      :replace
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -14,19 +14,15 @@ module KubernetesDeploy
       deploy_succeeded? ? "Provisioned" : "Unknown"
     end
 
-    def deploy_succeeded?
-      proxy_deployment_ready? && proxy_service_ready?
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def deploy_method
       :replace
     end
 
     private
+
+    def deploy_succeeded?
+      proxy_deployment_ready? && proxy_service_ready?
+    end
 
     def proxy_deployment_ready?
       return false unless status = @proxy_deployment["status"]

--- a/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
@@ -3,20 +3,18 @@ module KubernetesDeploy
   class ConfigMap < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def deploy_succeeded?
-      exists?
-    end
-
     def status
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_failed?
-      false
-    end
-
     def timeout_message
       UNUSUAL_FAILURE_MESSAGE
+    end
+
+    private
+
+    def deploy_succeeded?
+      exists?
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/cron_job.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cron_job.rb
@@ -3,16 +3,18 @@ module KubernetesDeploy
   class CronJob < KubernetesResource
     TIMEOUT = 30.seconds
 
+    def timeout_message
+      UNUSUAL_FAILURE_MESSAGE
+    end
+
+    private
+
     def deploy_succeeded?
       exists?
     end
 
     def deploy_failed?
       !exists?
-    end
-
-    def timeout_message
-      UNUSUAL_FAILURE_MESSAGE
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/elasticsearch.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/elasticsearch.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Elasticsearch < KubernetesResource
-    def deploy_succeeded?
-      super # success assumption, with warning
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def deploy_method
       :replace
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
@@ -7,12 +7,10 @@ module KubernetesDeploy
       exists? ? "Created" : "Unknown"
     end
 
+    private
+
     def deploy_succeeded?
       exists?
-    end
-
-    def deploy_failed?
-      false
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/memcached.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/memcached.rb
@@ -16,19 +16,15 @@ module KubernetesDeploy
       deploy_succeeded? ? "Provisioned" : "Unknown"
     end
 
-    def deploy_succeeded?
-      deployment_ready? && service_ready? && configmap_ready?
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def deploy_method
       :replace
     end
 
     private
+
+    def deploy_succeeded?
+      deployment_ready? && service_ready? && configmap_ready?
+    end
 
     def deployment_ready?
       return false unless status = @deployment["status"]

--- a/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
@@ -7,6 +7,8 @@ module KubernetesDeploy
       exists? ? @instance_data["status"]["phase"] : "Unknown"
     end
 
+    private
+
     def deploy_succeeded?
       status == "Bound"
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -37,18 +37,6 @@ module KubernetesDeploy
       "#{phase} (Reason: #{reason})"
     end
 
-    def deploy_succeeded?
-      if unmanaged?
-        phase == "Succeeded"
-      else
-        phase == "Running" && ready?
-      end
-    end
-
-    def deploy_failed?
-      failure_message.present?
-    end
-
     def timeout_message
       return STANDARD_TIMEOUT_MESSAGE unless readiness_probe_failure?
       probe_failure_msgs = @containers.map(&:readiness_fail_reason).compact
@@ -97,6 +85,18 @@ module KubernetesDeploy
     end
 
     private
+
+    def deploy_succeeded?
+      if unmanaged?
+        phase == "Succeeded"
+      else
+        phase == "Running" && ready?
+      end
+    end
+
+    def deploy_failed?
+      failure_message.present?
+    end
 
     def phase
       @instance_data.dig("status", "phase") || "Unknown"

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
@@ -7,10 +7,6 @@ module KubernetesDeploy
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_succeeded?
-      exists?
-    end
-
     def deploy_method
       # Required until https://github.com/kubernetes/kubernetes/issues/45398 changes
       :replace_force
@@ -18,6 +14,12 @@ module KubernetesDeploy
 
     def timeout_message
       UNUSUAL_FAILURE_MESSAGE
+    end
+
+    private
+
+    def deploy_succeeded?
+      exists?
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
@@ -12,7 +12,7 @@ module KubernetesDeploy
     def fetch_events(kubectl)
       own_events = super
       return own_events unless pods.present?
-      most_useful_pod = pods.find(&:deploy_failed?) || pods.find(&:deploy_timed_out?) || pods.first
+      most_useful_pod = pods.find { |p| p.deploy_status == "failed" } || pods.find { |p| p.deploy_status == "timed_out" } || pods.first
       own_events.merge(most_useful_pod.fetch_events(kubectl))
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
@@ -5,16 +5,14 @@ module KubernetesDeploy
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_succeeded?
-      exists?
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def timeout_message
       UNUSUAL_FAILURE_MESSAGE
+    end
+
+    private
+
+    def deploy_succeeded?
+      exists?
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -15,19 +15,15 @@ module KubernetesDeploy
       deploy_succeeded? ? "Provisioned" : "Unknown"
     end
 
-    def deploy_succeeded?
-      deployment_ready? && service_ready?
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def deploy_method
       :replace
     end
 
     private
+
+    def deploy_succeeded?
+      deployment_ready? && service_ready?
+    end
 
     def deployment_ready?
       return false unless status = @deployment["status"]

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -25,15 +25,6 @@ module KubernetesDeploy
       rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
     end
 
-    def deploy_succeeded?
-      desired_replicas == rollout_data["availableReplicas"].to_i &&
-      desired_replicas == rollout_data["readyReplicas"].to_i
-    end
-
-    def deploy_failed?
-      pods.present? && pods.all?(&:deploy_failed?)
-    end
-
     def desired_replicas
       return -1 unless exists?
       @instance_data["spec"]["replicas"].to_i
@@ -50,6 +41,15 @@ module KubernetesDeploy
     end
 
     private
+
+    def deploy_succeeded?
+      desired_replicas == rollout_data["availableReplicas"].to_i &&
+      desired_replicas == rollout_data["readyReplicas"].to_i
+    end
+
+    def deploy_failed?
+      pods.present? && pods.all? { |p| p.deploy_status == "failed" }
+    end
 
     def rollout_data
       return { "replicas" => 0 } unless exists?

--- a/lib/kubernetes-deploy/kubernetes_resource/resource_quota.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/resource_quota.rb
@@ -7,16 +7,14 @@ module KubernetesDeploy
       exists? ? "In effect" : "Unknown"
     end
 
-    def deploy_succeeded?
-      @instance_data.dig("spec", "hard") == @instance_data.dig("status", "hard")
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def timeout_message
       UNUSUAL_FAILURE_MESSAGE
+    end
+
+    private
+
+    def deploy_succeeded?
+      @instance_data.dig("spec", "hard") == @instance_data.dig("status", "hard")
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -22,22 +22,18 @@ module KubernetesDeploy
       end
     end
 
+    def timeout_message
+      "This service does not seem to select any pods. This means its spec.selector is probably incorrect."
+    end
+
+    private
+
     def deploy_succeeded?
       return false unless exists?
       return exists? unless requires_endpoints?
       # We can't use endpoints if we want the service to be able to fail fast when the pods are down
       exposes_zero_replica_deployment? || selects_some_pods?
     end
-
-    def deploy_failed?
-      false
-    end
-
-    def timeout_message
-      "This service does not seem to select any pods. This means its spec.selector is probably incorrect."
-    end
-
-    private
 
     def exposes_zero_replica_deployment?
       return false unless related_replica_count

--- a/lib/kubernetes-deploy/kubernetes_resource/service_account.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service_account.rb
@@ -7,16 +7,14 @@ module KubernetesDeploy
       exists? ? "Created" : "Unknown"
     end
 
-    def deploy_succeeded?
-      exists?
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def timeout_message
       UNUSUAL_FAILURE_MESSAGE
+    end
+
+    private
+
+    def deploy_succeeded?
+      exists?
     end
   end
 end

--- a/lib/kubernetes-deploy/kubernetes_resource/stateful_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/stateful_set.rb
@@ -19,6 +19,8 @@ module KubernetesDeploy
       rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
     end
 
+    private
+
     def deploy_succeeded?
       if update_strategy == ONDELETE
         # Gem cannot monitor update since it doesn't occur until delete
@@ -38,10 +40,8 @@ module KubernetesDeploy
 
     def deploy_failed?
       return false if update_strategy == ONDELETE
-      pods.present? && pods.any?(&:deploy_failed?)
+      pods.present? && pods.any? { |p| p.deploy_status == "failed" }
     end
-
-    private
 
     def update_strategy
       if @server_version < Gem::Version.new("1.7.0")

--- a/lib/kubernetes-deploy/kubernetes_resource/statefulservice.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/statefulservice.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Statefulservice < KubernetesResource
-    def deploy_succeeded?
-      super # success assumption, with warning
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def deploy_method
       :replace
     end

--- a/lib/kubernetes-deploy/kubernetes_resource/topic.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/topic.rb
@@ -1,14 +1,6 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Topic < KubernetesResource
-    def deploy_succeeded?
-      super # success assumption, with warning
-    end
-
-    def deploy_failed?
-      false
-    end
-
     def deploy_method
       :replace
     end

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -46,6 +46,23 @@ module KubernetesDeploy
       record_statuses_for_summary(@resources) if record_summary
     end
 
+    def final_status
+      statuses = @resources.group_by(&:deploy_status).keys
+      if statuses.include?("failed")
+        "failed"
+      elsif statuses.include?("timed_out")
+        "timed_out"
+      elsif statuses == %w(success)
+        "success"
+      else
+        "not_finished"
+      end
+    end
+
+    def unsuccessful_resources
+      @resources.reject { |r| r.deploy_status == "succeeded" }
+    end
+
     private
 
     def report_what_just_happened(new_successes, new_failures, new_timeouts)

--- a/lib/kubernetes-deploy/restart_task.rb
+++ b/lib/kubernetes-deploy/restart_task.rb
@@ -52,9 +52,9 @@ module KubernetesDeploy
       resources = build_watchables(deployments, start)
       ResourceWatcher.new(resources: resources, sync_mediator: @sync_mediator,
         logger: @logger, operation_name: "restart", timeout: @max_watch_seconds).run
-      failed_resources = resources.reject(&:deploy_succeeded?)
-      success = failed_resources.empty?
-      if !success && failed_resources.all?(&:deploy_timed_out?)
+      unsucceesful_resources = resources.reject { |r| r.deploy_status == "succeeded" }
+      success = unsucceesful_resources.empty?
+      if !success && unsucceesful_resources.all? { |r| r.deploy_status == "timed_out" }
         raise DeploymentTimeoutError
       end
       raise FatalDeploymentError unless success


### PR DESCRIPTION
Deploy statuses has been rather tricky to maintain. Currently a resource's status is not mutually exclusive, e.g.  it could be failed, started, timed_out, and successful. While initially this might have been helpful (e.g. an resource was eventually successful, but not before the timeout hit), it has actually made writing the logging code difficult. This PR is an attempt to make make statuses mutually exclusive. 

Resources now expose a single method: `deploy_status` which returns the status (currently as a string, could be a symbol) from a list of statuses in order of precedence. This ensures mutually exclusive states.

We also push the responsibility for the state of the deploy into the resource manager so that end users don't need to be concerned with checking each resource to determine the final state. 


Part of the motivation for this PR is making changes like https://github.com/Shopify/kubernetes-deploy/pull/282/files much smaller. 

Tests fail because I haven't updated the unit tests, I wanted 👀 before going all the way.
