### PR TITLE
[WIP] Add a state machine for deploy states

### DIFF
--- a/kubernetes-deploy.gemspec
+++ b/kubernetes-deploy.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ejson", "1.0.1"
   spec.add_dependency "colorize", "~> 0.8"
   spec.add_dependency "statsd-instrument", "~> 2.2"
+  spec.add_dependency "state_machines", "~> 0.5.0"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -10,6 +10,7 @@ require 'active_support/core_ext/hash/keys'
 require 'active_support/core_ext/array/conversions'
 require 'active_support/duration'
 require 'colorized_string'
+require 'state_machines'
 
 require 'kubernetes-deploy/version'
 require 'kubernetes-deploy/errors'

--- a/lib/kubernetes-deploy/kubernetes_resource/bucket.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/bucket.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Bucket < KubernetesResource
-    def deploy_succeeded?
-      return false unless deploy_started?
+    def deploy_succeeded
+      return false unless deploy_started
 
       unless @success_assumption_warning_shown
         @logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
@@ -15,7 +15,7 @@ module KubernetesDeploy
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cloudsql.rb
@@ -14,11 +14,11 @@ module KubernetesDeploy
       deploy_succeeded? ? "Provisioned" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       proxy_deployment_ready? && proxy_service_ready?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/config_map.rb
@@ -3,7 +3,7 @@ module KubernetesDeploy
   class ConfigMap < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def deploy_succeeded?
+    def deploy_succeeded
       exists?
     end
 
@@ -11,7 +11,7 @@ module KubernetesDeploy
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/cron_job.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/cron_job.rb
@@ -3,11 +3,11 @@ module KubernetesDeploy
   class CronJob < KubernetesResource
     TIMEOUT = 30.seconds
 
-    def deploy_succeeded?
+    def deploy_succeeded
       exists?
     end
 
-    def deploy_failed?
+    def deploy_failed
       !exists?
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/daemon_set.rb
@@ -16,20 +16,20 @@ module KubernetesDeploy
       rollout_data.map { |state_replicas, num| "#{num} #{state_replicas}" }.join(", ")
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       return false unless exists?
       rollout_data["desiredNumberScheduled"].to_i == rollout_data["updatedNumberScheduled"].to_i &&
       rollout_data["desiredNumberScheduled"].to_i == rollout_data["numberReady"].to_i &&
       current_generation == observed_generation
     end
 
-    def deploy_failed?
-      pods.present? && pods.any?(&:deploy_failed?)
+    def deploy_failed
+      pods.present? && pods.any?(&:deploy_failed)
     end
 
     def fetch_logs(kubectl)
       return {} unless pods.present?
-      most_useful_pod = pods.find(&:deploy_failed?) || pods.find(&:deploy_timed_out?) || pods.first
+      most_useful_pod = pods.find(&:deploy_failed) || pods.find(&:deploy_timed_out) || pods.first
       most_useful_pod.fetch_logs(kubectl)
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/elasticsearch.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/elasticsearch.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Elasticsearch < KubernetesResource
-    def deploy_succeeded?
+    def deploy_succeeded
       super # success assumption, with warning
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/ingress.rb
@@ -7,11 +7,11 @@ module KubernetesDeploy
       exists? ? "Created" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       exists?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
   end

--- a/lib/kubernetes-deploy/kubernetes_resource/memcached.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/memcached.rb
@@ -13,14 +13,14 @@ module KubernetesDeploy
     end
 
     def status
-      deploy_succeeded? ? "Provisioned" : "Unknown"
+      deploy_succeeded ? "Provisioned" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       deployment_ready? && service_ready? && configmap_ready?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/persistent_volume_claim.rb
@@ -7,11 +7,11 @@ module KubernetesDeploy
       exists? ? @instance_data["status"]["phase"] : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       status == "Bound"
     end
 
-    def deploy_failed?
+    def deploy_failed
       status == "Lost"
     end
   end

--- a/lib/kubernetes-deploy/kubernetes_resource/pod.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod.rb
@@ -21,7 +21,7 @@ module KubernetesDeploy
 
     def sync(mediator)
       super
-      raise_predates_deploy_error if exists? && unmanaged? && !deploy_started?
+      raise_predates_deploy_error if exists? && unmanaged? && !deploy_started
 
       if exists?
         update_container_statuses(@instance_data["status"])
@@ -29,7 +29,7 @@ module KubernetesDeploy
         @containers.each(&:reset_status)
       end
 
-      display_logs(mediator) if unmanaged? && deploy_succeeded?
+      display_logs(mediator) if unmanaged? && deploy_succeeded
     end
 
     def status
@@ -37,7 +37,7 @@ module KubernetesDeploy
       "#{phase} (Reason: #{reason})"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       if unmanaged?
         phase == "Succeeded"
       else
@@ -45,7 +45,7 @@ module KubernetesDeploy
       end
     end
 
-    def deploy_failed?
+    def deploy_failed
       failure_message.present?
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_disruption_budget.rb
@@ -7,7 +7,7 @@ module KubernetesDeploy
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       exists?
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_set_base.rb
@@ -12,7 +12,7 @@ module KubernetesDeploy
     def fetch_events(kubectl)
       own_events = super
       return own_events unless pods.present?
-      most_useful_pod = pods.find(&:deploy_failed?) || pods.find(&:deploy_timed_out?) || pods.first
+      most_useful_pod = pods.find(&:deploy_failed) || pods.find(&:deploy_timed_out) || pods.first
       own_events.merge(most_useful_pod.fetch_events(kubectl))
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/pod_template.rb
@@ -5,11 +5,11 @@ module KubernetesDeploy
       exists? ? "Available" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       exists?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/redis.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/redis.rb
@@ -15,11 +15,11 @@ module KubernetesDeploy
       deploy_succeeded? ? "Provisioned" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       deployment_ready? && service_ready?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/replica_set.rb
@@ -25,13 +25,13 @@ module KubernetesDeploy
       rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       desired_replicas == rollout_data["availableReplicas"].to_i &&
       desired_replicas == rollout_data["readyReplicas"].to_i
     end
 
-    def deploy_failed?
-      pods.present? && pods.all?(&:deploy_failed?)
+    def deploy_failed
+      pods.present? && pods.all?(&:deploy_failed)
     end
 
     def desired_replicas

--- a/lib/kubernetes-deploy/kubernetes_resource/resource_quota.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/resource_quota.rb
@@ -7,11 +7,11 @@ module KubernetesDeploy
       exists? ? "In effect" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       @instance_data.dig("spec", "hard") == @instance_data.dig("status", "hard")
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/service.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service.rb
@@ -22,14 +22,14 @@ module KubernetesDeploy
       end
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       return false unless exists?
       return exists? unless requires_endpoints?
       # We can't use endpoints if we want the service to be able to fail fast when the pods are down
       exposes_zero_replica_deployment? || selects_some_pods?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 
@@ -65,7 +65,7 @@ module KubernetesDeploy
 
     def related_replica_count
       return 0 unless selector.present?
-      return unless @related_deployments.length == 1
+      return unless @related_deployments && @related_deployments.length == 1
       @related_deployments.first["spec"]["replicas"].to_i
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/service_account.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/service_account.rb
@@ -7,11 +7,11 @@ module KubernetesDeploy
       exists? ? "Created" : "Unknown"
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       exists?
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/stateful_set.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/stateful_set.rb
@@ -8,9 +8,9 @@ module KubernetesDeploy
 
     SYNC_DEPENDENCIES = %w(Pod)
     def sync(mediator)
+      @server_version ||= mediator.kubectl.server_version
       super
       @pods = exists? ? find_pods(mediator) : []
-      @server_version ||= mediator.kubectl.server_version
     end
 
     def status
@@ -19,7 +19,7 @@ module KubernetesDeploy
       rollout_data.map { |state_replicas, num| "#{num} #{state_replicas.chop.pluralize(num)}" }.join(", ")
     end
 
-    def deploy_succeeded?
+    def deploy_succeeded
       if update_strategy == ONDELETE
         # Gem cannot monitor update since it doesn't occur until delete
         unless @success_assumption_warning_shown
@@ -36,9 +36,9 @@ module KubernetesDeploy
       end
     end
 
-    def deploy_failed?
+    def deploy_failed
       return false if update_strategy == ONDELETE
-      pods.present? && pods.any?(&:deploy_failed?)
+      pods.present? && pods.any?(&:deploy_failed)
     end
 
     private

--- a/lib/kubernetes-deploy/kubernetes_resource/statefulservice.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/statefulservice.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Statefulservice < KubernetesResource
-    def deploy_succeeded?
+    def deploy_succeeded
       super # success assumption, with warning
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 

--- a/lib/kubernetes-deploy/kubernetes_resource/topic.rb
+++ b/lib/kubernetes-deploy/kubernetes_resource/topic.rb
@@ -1,11 +1,11 @@
 # frozen_string_literal: true
 module KubernetesDeploy
   class Topic < KubernetesResource
-    def deploy_succeeded?
+    def deploy_succeeded
       super # success assumption, with warning
     end
 
-    def deploy_failed?
+    def deploy_failed
       false
     end
 


### PR DESCRIPTION
Deploy statuses has been rather tricky to maintain. Currently a resource's status is not mutually exclusive, e.g. it could be failed, started, timed_out, and successful. While initially this might have been helpful (e.g. an resource was eventually successful, but not before the timeout hit), it has actually made writing the logging code difficult. To fix this introduce a [state_machine](https://github.com/state-machines/state_machines)


Part of the motivation for this PR is making changes like https://github.com/Shopify/kubernetes-deploy/pull/282/files much smaller.

Tests are failing...