### PR TITLE
WATCH resources without Deploy

### DIFF
--- a/bin/watch-resources
+++ b/bin/watch-resources
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+require 'kubernetes-deploy'
+require 'kubernetes-deploy/watch_only_task'
+
+bindings = {}
+template_dir = nil
+
+ARGV.options do |opts|
+  opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
+    "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") do |binds|
+    bindings.merge!(KubernetesDeploy::BindingsParser.parse(binds))
+  end
+  opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
+
+  opts.on_tail("-h", "--help", "Print this help") do
+    puts opts
+    exit
+  end
+  opts.parse!
+end
+
+namespace = ARGV[0]
+context = ARGV[1]
+logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
+
+KubernetesDeploy::WatchOnlyTask.new(
+  namespace: namespace,
+  context: context,
+  template_dir: template_dir,
+  bindings: bindings,
+  logger: logger,
+  sha: ENV["REVISION"]
+).run

--- a/bin/watch-resources
+++ b/bin/watch-resources
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 require 'optparse'
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift(File.expand_path('../../lib', __FILE__))
 require 'kubernetes-deploy'
 require 'kubernetes-deploy/watch_only_task'
 
@@ -27,11 +27,21 @@ namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
-KubernetesDeploy::WatchOnlyTask.new(
-  namespace: namespace,
-  context: context,
-  template_dir: template_dir,
-  bindings: bindings,
-  logger: logger,
-  sha: ENV["REVISION"]
-).run
+begin
+  failed_resources = 0
+  KubernetesDeploy::OptionsHelper.with_validated_template_dir(template_dir) do |dir|
+    failed_resources = KubernetesDeploy::WatchOnlyTask.new(
+      namespace: namespace,
+      context: context,
+      template_dir: dir,
+      bindings: bindings,
+      logger: logger,
+      sha: ENV["REVISION"]
+    ).run
+  end
+rescue KubernetesDeploy::FatalDeploymentError
+  exit(1)
+end
+
+exit(1) if failed_resources > 0
+exit(0)

--- a/bin/watch-resources
+++ b/bin/watch-resources
@@ -27,8 +27,8 @@ namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
 
+failed_resources = 0
 begin
-  failed_resources = 0
   KubernetesDeploy::OptionsHelper.with_validated_template_dir(template_dir) do |dir|
     failed_resources = KubernetesDeploy::WatchOnlyTask.new(
       namespace: namespace,
@@ -43,5 +43,4 @@ rescue KubernetesDeploy::FatalDeploymentError
   exit(1)
 end
 
-exit(1) if failed_resources > 0
 exit(0)

--- a/lib/kubernetes-deploy/deferred_summary_logging.rb
+++ b/lib/kubernetes-deploy/deferred_summary_logging.rb
@@ -36,15 +36,19 @@ module KubernetesDeploy
     # Outputs the deferred summary information saved via @logger.summary.add_action and @logger.summary.add_paragraph
     def print_summary(status)
       status_string = status.to_s.humanize.upcase
-      if status == :success
+      case status
+      when :success
         heading("Result: ", status_string, :green)
         level = :info
-      elsif status == :timed_out
+      when :timed_out
         heading("Result: ", status_string, :yellow)
         level = :fatal
-      else
+      when :fatal
         heading("Result: ", status_string, :red)
         level = :fatal
+      else
+        heading("Result: ", status_string, :magenta)
+        level = :info
       end
 
       if (actions_sentence = summary.actions_sentence.presence)

--- a/lib/kubernetes-deploy/render_task.rb
+++ b/lib/kubernetes-deploy/render_task.rb
@@ -29,7 +29,8 @@ module KubernetesDeploy
       @logger.phase_heading("Initializing render task")
 
       filenames = if only_filenames.empty?
-        TemplateDiscovery.new(@template_dir).templates
+        discovery = TemplateDiscovery.new(namespace: @namespace, context: @context, logger: @logger)
+        discovery.templates_from_dir(@template_dir)
       else
         only_filenames
       end

--- a/lib/kubernetes-deploy/renderer.rb
+++ b/lib/kubernetes-deploy/renderer.rb
@@ -31,6 +31,14 @@ module KubernetesDeploy
       end
     end
 
+    def render_files(filenames)
+      files = {}
+      filenames.each do |filename|
+        files[filename] = split_templates(filename)
+      end
+      files
+    end
+
     def render_template(filename, raw_template)
       return raw_template unless File.extname(filename) == ".erb"
 
@@ -75,6 +83,28 @@ module KubernetesDeploy
     end
 
     private
+
+    def split_templates(filename)
+      results = []
+      file_content = File.read(File.join(@template_dir, filename))
+      rendered_content = render_template(filename, file_content)
+
+      YAML.load_stream(rendered_content, "<rendered> #{filename}") do |doc|
+        next if doc.blank?
+        unless doc.is_a?(Hash)
+          raise InvalidTemplateError.new("Template is not a valid Kubernetes manifest",
+            filename: filename, content: doc)
+        end
+        results << doc
+      end
+
+      results
+    rescue InvalidTemplateError => e
+      e.filename ||= filename
+      raise e
+    rescue Psych::SyntaxError => e
+      raise InvalidTemplateError.new("Failed to render and parse template: #{e}", filename: filename)
+    end
 
     def template_variables
       {

--- a/lib/kubernetes-deploy/resource_watcher.rb
+++ b/lib/kubernetes-deploy/resource_watcher.rb
@@ -44,6 +44,9 @@ module KubernetesDeploy
         end
       end
       record_statuses_for_summary(@resources) if record_summary
+
+      _successful_resources, failed_resources = @resources.partition(&:deploy_succeeded?)
+      failed_resources.length
     end
 
     private

--- a/lib/kubernetes-deploy/template_discovery.rb
+++ b/lib/kubernetes-deploy/template_discovery.rb
@@ -2,14 +2,45 @@
 
 module KubernetesDeploy
   class TemplateDiscovery
-    def initialize(template_dir)
-      @template_dir = template_dir
+    def initialize(namespace:, context:, logger:, namespace_tags: [])
+      @namespace = namespace
+      @context = context
+      @logger = logger
+      @namespace_tags = namespace_tags
     end
 
-    def templates
-      Dir.foreach(@template_dir).select do |filename|
+    def resources(template_dir, renderer, crds)
+      resources = []
+      template_files = templates_from_dir(template_dir)
+      renderer.render_files(template_files).each do |filename, definitions|
+        definitions.each do |r_def|
+          crd = crds[r_def["kind"]]&.first
+          resources << build_resource(r_def, filename, crd)
+        end
+      end
+      resources
+    end
+
+    def templates_from_dir(template_dir)
+      Dir.foreach(template_dir).select do |filename|
         filename.end_with?(".yml.erb", ".yml", ".yaml", ".yaml.erb")
       end
+    end
+
+    private
+
+    def build_resource(definition, filename, crd)
+      KubernetesResource.build(
+        namespace: @namespace,
+        context: @context,
+        logger: @logger,
+        definition: definition,
+        statsd_tags: @namespace_tags,
+        crd: crd
+      )
+    rescue InvalidTemplateError => e
+      e.filename ||= filename
+      raise e
     end
   end
 end

--- a/lib/kubernetes-deploy/watch_only_task.rb
+++ b/lib/kubernetes-deploy/watch_only_task.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'kubernetes-deploy/resource_watcher'
+require 'kubernetes-deploy/renderer'
+require 'kubernetes-deploy/cluster_resource_discovery'
+require 'kubernetes-deploy/template_discovery'
+
+module KubernetesDeploy
+  class WatchOnlyTask
+    def initialize(namespace:, context:, template_dir:, bindings:, logger:, sha: '')
+      @namespace = namespace
+      @context = context
+      @template_dir = template_dir
+      @logger = logger
+      @sha = sha
+      @bindings = bindings
+    end
+
+    def run
+      @logger.phase_heading("Initializing task")
+      resources = resources_from_templates
+      # should add secrets from ejson or log that they are being skipped
+
+      @logger.phase_heading("Simulating watch")
+      watch_resources(resources)
+
+      @logger.print_summary("Fake watch")
+    end
+
+    private
+
+    def watch_resources(resources)
+      watcher = ResourceWatcher.new(
+        resources: resources,
+        logger: @logger,
+        context: @context,
+        namespace: @namespace
+      )
+      watcher.run
+    end
+
+    def resources_from_templates
+      renderer = Renderer.new(current_sha: @sha, template_dir: @template_dir, logger: @logger, bindings: @bindings)
+      discovery = TemplateDiscovery.new(namespace: @namespace, context: @context, logger: @logger)
+      resources = discovery.resources(@template_dir, renderer, cluster_resource_discoverer.crds)
+      resources.reject! do |r|
+        if r.type == "Pod"
+          basename = r.name.split("-")[0..-3].join("-")
+          @logger.warn("Not simulating watch for #{basename} pod because its real ID cannot be determined")
+        end
+      end
+
+      @logger.info("Will look for the following resources in #{@context}/#{@namespace}:")
+      resources.each do |r|
+        r.deploy_started_at = 5.minutes.ago # arbitrary time in the past
+        @logger.info("  - #{r.id}")
+      end
+      resources
+    end
+
+    def cluster_resource_discoverer
+      @cluster_resource_discoverer ||= ClusterResourceDiscovery.new(
+        namespace: @namespace,
+        context: @context,
+        logger: @logger,
+        namespace_tags: @namespace_tags
+      )
+    end
+  end
+end


### PR DESCRIPTION
continue of: https://github.com/Shopify/kubernetes-deploy/pull/388



  - added support for `--template-dir=-`
  - exit code 1 if error is detected
  - fixes CRDS group_by(:kind)

TODOS: (if you are ok with the PR and plan to merge it)
  - [ ] add tests
  - [ ] update docs
  - [ ] add exe -> exe/kubernetes-watch



sample call:

```
kubectl apply -f infra.yml
cat infra | bin/watch-resources  --template-dir=- $NS $CTX
```





