### PR TITLE
Add ClusterRoleBinding to Phase 3

### DIFF
--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -71,6 +71,7 @@ module KubernetesDeploy
         ServiceAccount
         Role
         RoleBinding
+        ClusterRoleBinding
         Secret
         Pod
       )


### PR DESCRIPTION
What are you trying to accomplish with this PR?
Add ClusterRoleBinding to Phase 3: Predeploying. ClusterRoleBinding should be used with RoleBinding simultaneously.
