### PR TITLE
[Feature] Add `kubectl diff` implementation as `kubernetes-diff` and `krane diff`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ This repo also includes related tools for [running tasks](#kubernetes-run) and [
 * [Prerequisites](#prerequisites-2)
 * [Usage](#usage-3)
 
+**KUBERNETES-DIFF**
+* [Prerequisites](#prerequisites-3)
+* [Usage](#usage-4)
+
 **CONTRIBUTING**
 * [Contributing](#contributing)
 * [Code of Conduct](#code-of-conduct)
@@ -522,6 +526,27 @@ kubernetes-render --template-dir=./path/to/template/dir template.yaml.erb > temp
 
 - `--template-dir=DIR`: Used to set the directory to interpret template names relative to. This is often the same directory passed as `--template-dir` when running `kubernetes-deploy` to actually deploy templates. Set `$ENVIRONMENT` instead to use `config/deploy/$ENVIRONMENT`. This flag also supports reading from STDIN. You can do this by using `--template-dir=-`.
 - `--bindings=BINDINGS`: Makes additional variables available to your ERB templates. For example, `kubernetes-render --bindings=color=blue,size=large some-template.yaml.erb` will expose `color` and `size` to `some-template.yaml.erb`.
+
+
+# kubernetes-diff / krane diff
+`kubernetes-diff` is a tool for showing difference between local files and current version in the cluster. Recommended to use as a part of your Kubernetes CI/CD to validate changes before applying them.
+Has been also implemented as `krane diff` version as a preparation to the renaming project.
+
+
+## Prerequisites
+ * `kubernetes-diff` works only in Kubernetes clusters with `server-side dry-run` enabled. [Documentation](https://kubernetes.io/blog/2019/01/14/apiserver-dry-run-and-kubectl-diff/)
+
+## Usage
+To show a diff between local and the cluster state run:
+
+```
+kubernetes-diff <kube namespace> <kube context> <arguments>
+krane diff <kube namespace> <kube context> <arguments>
+```
+
+*Options:*
+Refer to `kubernetes-diff --help` for the authoritative set of options.
+Refer to `krane help diff` for the authoritative set of options.
 
 
 # Contributing

--- a/exe/kubernetes-diff
+++ b/exe/kubernetes-diff
@@ -67,7 +67,6 @@ begin
 
     runner.run!(stream: STDOUT)
   end
-  # TODO: Rename errors
 rescue KubernetesDeploy::DeploymentTimeoutError
   exit(70)
 rescue KubernetesDeploy::FatalDeploymentError

--- a/exe/kubernetes-diff
+++ b/exe/kubernetes-diff
@@ -1,0 +1,78 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'kubernetes-deploy/diff_task'
+require 'kubernetes-deploy/options_helper'
+require 'kubernetes-deploy/bindings_parser'
+require 'kubernetes-deploy/label_selector'
+
+require 'optparse'
+
+template_dir = nil
+template_paths = []
+bindings = {}
+verbose_log_prefix = false
+selector = nil
+
+ARGV.options do |opts|
+  parser = KubernetesDeploy::BindingsParser.new
+  opts.on("--bindings=BINDINGS", "Expose additional variables to ERB templates " \
+    "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") { |b| parser.add(b) }
+
+  opts.on("--verbose-log-prefix", "Add [context][namespace] to the log prefix") { verbose_log_prefix = true }
+  opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
+  opts.on("-f [PATHS]", Array, "comma separated list of template directories and/or filenames") do |paths|
+    template_paths += paths
+  end
+
+  opts.on("--selector=SELECTOR", "Ensure that all resources in your template dir match the given selector, " \
+    "and restrict pruning to deployed resources it selects.  (format: k1=v1,k2=v2)") do |s|
+    selector = KubernetesDeploy::LabelSelector.parse(s)
+  end
+
+  opts.on_tail("-h", "--help", "Print this help") do
+    puts opts
+    exit
+  end
+  opts.on_tail("-v", "--version", "Show version") do
+    puts "v#{KubernetesDeploy::VERSION}"
+    exit
+  end
+  opts.parse!
+  bindings = parser.parse
+end
+
+namespace = ARGV[0]
+context = ARGV[1]
+logger = KubernetesDeploy::FormattedLogger.build(namespace, context, verbose_prefix: verbose_log_prefix)
+
+# Deprecation path: this can be removed when --template-dir is fully replaced by -f
+if template_dir && !template_paths.empty?
+  logger.error("Error: --template-dir and -f flags cannot be combined")
+  exit(1)
+end
+template_paths = [template_dir] if template_paths.empty? && template_dir
+
+begin
+  KubernetesDeploy::OptionsHelper.with_processed_template_paths(template_paths) do |paths|
+    runner = KubernetesDeploy::DiffTask.new(
+      namespace: namespace,
+      context: context,
+      current_sha: ENV["REVISION"],
+      template_paths: paths,
+      bindings: bindings,
+      logger: logger,
+      selector: selector,
+    )
+
+    runner.run!(stream: STDOUT)
+  end
+  # TODO: Rename errors
+rescue KubernetesDeploy::DeploymentTimeoutError
+  exit(70)
+rescue KubernetesDeploy::FatalDeploymentError
+  exit(1)
+rescue KubernetesDeploy::OptionsHelper::OptionsError => e
+  logger.error(e.message)
+  exit(1)
+end

--- a/exe/kubernetes-diff
+++ b/exe/kubernetes-diff
@@ -8,7 +8,6 @@ require 'kubernetes-deploy/label_selector'
 
 require 'optparse'
 
-template_dir = nil
 template_paths = []
 bindings = {}
 verbose_log_prefix = false
@@ -20,8 +19,7 @@ ARGV.options do |opts|
     "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')") { |b| parser.add(b) }
 
   opts.on("--verbose-log-prefix", "Add [context][namespace] to the log prefix") { verbose_log_prefix = true }
-  opts.on("--template-dir=DIR", "Set the template dir (default: config/deploy/$ENVIRONMENT)") { |v| template_dir = v }
-  opts.on("-f [PATHS]", Array, "comma separated list of template directories and/or filenames") do |paths|
+  opts.on("-f [PATHS]", Array, "comma separated list of template directories and/or filenames ( Default: current directory )") do |paths|
     template_paths += paths
   end
 
@@ -45,13 +43,6 @@ end
 namespace = ARGV[0]
 context = ARGV[1]
 logger = KubernetesDeploy::FormattedLogger.build(namespace, context, verbose_prefix: verbose_log_prefix)
-
-# Deprecation path: this can be removed when --template-dir is fully replaced by -f
-if template_dir && !template_paths.empty?
-  logger.error("Error: --template-dir and -f flags cannot be combined")
-  exit(1)
-end
-template_paths = [template_dir] if template_paths.empty? && template_dir
 
 begin
   KubernetesDeploy::OptionsHelper.with_processed_template_paths(template_paths) do |paths|

--- a/lib/krane/cli/diff_command.rb
+++ b/lib/krane/cli/diff_command.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+module Krane
+    module CLI
+      class DiffCommand
+        OPTIONS = {
+          "bindings" => { type: :string, banner: "bindings",
+                             desc: "(format: k1=v1,k2=v2, JSON string or file (JSON or YAML) path prefixed by '@')" },
+          "template_paths" => { type: :array, aliases: "-f", default: ["."],
+                             desc: "space separated list of template directories and/or filenames (default: current directory)" },
+          "selector" => { type: :string, banner: "'label=value'",
+                          desc: "Select workloads by selector(s)" },
+        }
+
+        def self.from_options(namespace, context, options)
+          require 'kubernetes-deploy/diff_task'
+          require 'kubernetes-deploy/bindings_parser'
+          require 'kubernetes-deploy/label_selector'
+          require 'optparse'
+
+          parser = KubernetesDeploy::BindingsParser.new
+          parser.add(options[:bindings]) if options[:bindings]
+          logger = KubernetesDeploy::FormattedLogger.build(namespace, context)
+          selector = KubernetesDeploy::LabelSelector.parse(options[:selector]) if options[:selector]
+
+          runner = KubernetesDeploy::DiffTask.new(
+            namespace: namespace,
+            context: context,
+            current_sha: ENV["REVISION"],
+            template_paths: options[:template_paths],
+            bindings: parser.parse,
+            logger: logger,
+            selector: selector
+          )
+
+          runner.run!(stream: STDOUT)
+        end
+      end
+    end
+  end

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -4,6 +4,7 @@ require 'krane'
 require 'thor'
 require 'krane/cli/version_command'
 require 'krane/cli/restart_command'
+require 'krane/cli/diff_command'
 
 module Krane
   module CLI
@@ -28,6 +29,14 @@ module Krane
       def restart(namespace, context)
         rescue_and_exit do
           RestartCommand.from_options(namespace, context, options)
+        end
+      end
+
+      desc("diff NAMESPACE CONTEXT", "Diff")
+      expand_options(DiffCommand::OPTIONS)
+      def diff(namespace, context)
+        rescue_and_exit do
+          DiffCommand.from_options(namespace, context, options)
         end
       end
 

--- a/lib/kubernetes-deploy.rb
+++ b/lib/kubernetes-deploy.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'kubernetes-deploy/deploy_task'
+require 'kubernetes-deploy/diff_task'
 require 'kubernetes-deploy/render_task'
 require 'kubernetes-deploy/restart_task'
 require 'kubernetes-deploy/runner_task'

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -479,12 +479,14 @@ module KubernetesDeploy
         bad_files = find_bad_files_from_kubectl_output(line)
         if bad_files.present?
           bad_files.each do |f|
-            if filenames_with_sensitive_content.include?(f[:filename])
+            record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
+            ### Disabled until the bug is fixed or skip CLI option introduced ###
+            # if filenames_with_sensitive_content.include?(f[:filename])
               # Hide the error and template contents in case it has senitive information
-              record_invalid_template(err: "SUPPRESSED FOR SECURITY", filename: f[:filename], content: nil)
-            else
-              record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
-            end
+            #   record_invalid_template(err: "SUPPRESSED FOR SECURITY", filename: f[:filename], content: nil)
+            # else
+            #   record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
+            # end
           end
         else
           unidentified_errors << line

--- a/lib/kubernetes-deploy/deploy_task.rb
+++ b/lib/kubernetes-deploy/deploy_task.rb
@@ -479,14 +479,12 @@ module KubernetesDeploy
         bad_files = find_bad_files_from_kubectl_output(line)
         if bad_files.present?
           bad_files.each do |f|
-            record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
-            ### Disabled until the bug is fixed or skip CLI option introduced ###
-            # if filenames_with_sensitive_content.include?(f[:filename])
+            if filenames_with_sensitive_content.include?(f[:filename])
               # Hide the error and template contents in case it has senitive information
-            #   record_invalid_template(err: "SUPPRESSED FOR SECURITY", filename: f[:filename], content: nil)
-            # else
-            #   record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
-            # end
+              record_invalid_template(err: "SUPPRESSED FOR SECURITY", filename: f[:filename], content: nil)
+            else
+              record_invalid_template(err: f[:err], filename: f[:filename], content: f[:content])
+            end
           end
         else
           unidentified_errors << line

--- a/lib/kubernetes-deploy/diff_task.rb
+++ b/lib/kubernetes-deploy/diff_task.rb
@@ -1,0 +1,315 @@
+# frozen_string_literal: true
+require 'yaml'
+require 'shellwords'
+require 'tempfile'
+require 'fileutils'
+
+require 'kubernetes-deploy/common'
+require 'kubernetes-deploy/concurrency'
+require 'kubernetes-deploy/kubernetes_resource'
+%w(
+  custom_resource
+  cloudsql
+  config_map
+  deployment
+  ingress
+  persistent_volume_claim
+  pod
+  network_policy
+  service
+  pod_template
+  pod_disruption_budget
+  replica_set
+  service_account
+  daemon_set
+  resource_quota
+  stateful_set
+  cron_job
+  job
+  custom_resource_definition
+  horizontal_pod_autoscaler
+  secret
+).each do |subresource|
+  require "kubernetes-deploy/kubernetes_resource/#{subresource}"
+end
+require 'kubernetes-deploy/kubectl'
+require 'kubernetes-deploy/kubeclient_builder'
+require 'kubernetes-deploy/ejson_secret_provisioner'
+require 'kubernetes-deploy/cluster_resource_discovery'
+require 'kubernetes-deploy/template_sets'
+require 'kubernetes-deploy/renderer'
+
+module KubernetesDeploy
+  class DiffTask
+    def server_version
+      kubectl.server_version
+    end
+
+    def initialize(
+      namespace:, context:, current_sha:, logger: nil, kubectl_instance: nil, bindings: {},
+      selector: nil, template_paths: [], template_dir: nil
+    )
+      template_dir = File.expand_path(template_dir) if template_dir
+      template_paths = (template_paths.map { |path| File.expand_path(path) } << template_dir).compact
+
+      @logger = logger || KubernetesDeploy::FormattedLogger.build(namespace, context)
+      @template_sets = TemplateSets.from_dirs_and_files(paths: template_paths, logger: @logger)
+      @task_config = KubernetesDeploy::TaskConfig.new(context, namespace, @logger)
+      @bindings = bindings
+      @namespace = namespace
+      @namespace_tags = []
+      @context = context
+      @current_sha = current_sha
+      @kubectl = kubectl_instance
+      @selector = selector
+    end
+
+    def run(*args)
+      run!(*args)
+      true
+    rescue FatalDeploymentError
+      false
+    end
+
+    def run!(stream: STDOUT)
+      @logger.reset
+
+      @logger.phase_heading("Validating resources")
+      validate_configuration
+      resources = discover_resources
+      validate_resources(resources)
+
+      @logger.phase_heading("Running diff")
+      run_diff(resources, stream)
+
+      @logger.print_summary(:success)
+    end
+
+    private
+
+    def kubeclient_builder
+      @kubeclient_builder ||= KubeclientBuilder.new
+    end
+
+    def cluster_resource_discoverer
+      @cluster_resource_discoverer ||= ClusterResourceDiscovery.new(
+        namespace: @namespace,
+        context: @context,
+        logger: @logger,
+        namespace_tags: @namespace_tags
+      )
+    end
+
+    def ejson_provisioners
+      @ejson_provisoners ||= @template_sets.ejson_secrets_files.map do |ejson_secret_file|
+        EjsonSecretProvisioner.new(
+          namespace: @namespace,
+          context: @context,
+          ejson_keys_secret: ejson_keys_secret,
+          ejson_file: ejson_secret_file,
+          logger: @logger,
+          statsd_tags: @namespace_tags,
+          selector: @selector,
+        )
+      end
+    end
+
+    def validate_resources(resources)
+      KubernetesDeploy::Concurrency.split_across_threads(resources) do |r|
+        r.validate_definition(kubectl, selector: @selector)
+      end
+
+      resources.select(&:has_warnings?).each do |resource|
+        record_warnings(warning: resource.validation_warning_msg, filename: File.basename(resource.file_path))
+      end
+
+      failed_resources = resources.select(&:validation_failed?)
+      return unless failed_resources.present?
+
+      failed_resources.each do |r|
+        content = File.read(r.file_path) if File.file?(r.file_path) && !r.sensitive_template_content?
+        record_invalid_template(err: r.validation_error_msg, filename: File.basename(r.file_path), content: content)
+      end
+      raise FatalDeploymentError, "Template validation failed"
+    end
+
+    def secrets_from_ejson
+      ejson_provisioners.flat_map(&:resources)
+    end
+
+    def discover_resources
+      @logger.info("Discovering resources:")
+      resources = []
+      crds_by_kind = cluster_resource_discoverer.crds.group_by(&:kind)
+      @template_sets.with_resource_definitions(render_erb: true,
+          current_sha: @current_sha, bindings: @bindings) do |r_def|
+        crd = crds_by_kind[r_def["kind"]]&.first
+        r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,
+          statsd_tags: @namespace_tags, crd: crd)
+        resources << r
+        @logger.info("  - #{r.id}")
+      end
+
+      secrets_from_ejson.each do |secret|
+        resources << secret
+        @logger.info("  - #{secret.id} (from ejson)")
+      end
+
+      resources.sort
+    rescue InvalidTemplateError => e
+      record_invalid_template(err: e.message, filename: e.filename, content: e.content)
+      raise FatalDeploymentError, "Failed to render and parse template"
+    end
+
+    def record_invalid_template(err:, filename:, content: nil)
+      debug_msg = ColorizedString.new("Invalid template: #{filename}\n").red
+      debug_msg += "> Error message:\n#{FormattedLogger.indent_four(err)}"
+      if content
+        debug_msg += if content =~ /kind:\s*Secret/
+          "\n> Template content: Suppressed because it may contain a Secret"
+        else
+          "\n> Template content:\n#{FormattedLogger.indent_four(content)}"
+        end
+      end
+      @logger.summary.add_paragraph(debug_msg)
+    end
+
+    def record_warnings(warning:, filename:)
+      warn_msg = "Template warning: #{filename}\n"
+      warn_msg += "> Warning message:\n#{FormattedLogger.indent_four(warning)}"
+      @logger.summary.add_paragraph(ColorizedString.new(warn_msg).yellow)
+    end
+
+    def validate_configuration()
+      errors = []
+      errors += kubeclient_builder.validate_config_files
+      errors += @template_sets.validate
+
+      if @namespace.blank?
+        errors << "Namespace must be specified"
+      end
+
+      if @context.blank?
+        errors << "Context must be specified"
+      end
+
+      unless errors.empty?
+        @logger.summary.add_paragraph(errors.map { |err| "- #{err}" }.join("\n"))
+        raise FatalDeploymentError, "Configuration invalid"
+      end
+
+      confirm_context_exists
+      confirm_namespace_exists
+      @logger.info("Using resource selector #{@selector}") if @selector
+      @namespace_tags |= tags_from_namespace_labels
+      @logger.info("All required parameters and files are present")
+    end
+
+    def confirm_context_exists
+      out, err, st = kubectl.run("config", "get-contexts", "-o", "name",
+        use_namespace: false, use_context: false, log_failure: false)
+      available_contexts = out.split("\n")
+      if !st.success?
+        raise FatalDeploymentError, err
+      elsif !available_contexts.include?(@context)
+        raise FatalDeploymentError, "Context #{@context} is not available. Valid contexts: #{available_contexts}"
+      end
+      confirm_cluster_reachable
+      @logger.info("Context #{@context} found")
+    end
+
+    def confirm_cluster_reachable
+      success = false
+      with_retries(2) do
+        begin
+          success = kubectl.version_info
+        rescue KubectlError
+          success = false
+        end
+      end
+      raise FatalDeploymentError, "Failed to reach server for #{@context}" unless success
+      TaskConfigValidator.new(@task_config, kubectl, kubeclient_builder, only: [:validate_server_version]).valid?
+    end
+
+    def confirm_namespace_exists
+      raise FatalDeploymentError, "Namespace #{@namespace} not found" unless namespace_definition.present?
+      @logger.info("Namespace #{@namespace} found")
+    end
+
+    def namespace_definition
+      @namespace_definition ||= begin
+        definition, _err, st = kubectl.run("get", "namespace", @namespace, use_namespace: false,
+          log_failure: true, raise_if_not_found: true, attempts: 3, output: 'json')
+        st.success? ? JSON.parse(definition, symbolize_names: true) : nil
+      end
+    rescue Kubectl::ResourceNotFoundError
+      nil
+    end
+
+    def tags_from_namespace_labels
+      return [] if namespace_definition.blank?
+      namespace_labels = namespace_definition.fetch(:metadata, {}).fetch(:labels, {})
+      namespace_labels.map { |key, value| "#{key}:#{value}" }
+    end
+
+    def kubectl
+      @kubectl ||= Kubectl.new(namespace: @namespace, context: @context, logger: @logger, log_failure_by_default: true)
+    end
+
+    def ejson_keys_secret
+      @ejson_keys_secret ||= begin
+        out, err, st = kubectl.run("get", "secret", EjsonSecretProvisioner::EJSON_KEYS_SECRET, output: "json",
+          raise_if_not_found: true, attempts: 3, output_is_sensitive: true, log_failure: true)
+        unless st.success?
+          raise EjsonSecretError, "Error retrieving Secret/#{EjsonSecretProvisioner::EJSON_KEYS_SECRET}: #{err}"
+        end
+        JSON.parse(out)
+      end
+    end
+
+    def with_retries(limit)
+      retried = 0
+      while retried <= limit
+        success = yield
+        break if success
+        retried += 1
+      end
+    end
+
+    def run_diff(resources, stream)
+      return if resources.empty?
+
+      if resources.length > 1
+        @logger.info("Running diff for following resources:")
+        resources.each do |r|
+          @logger.info("- #{r.id}")
+        end
+      else
+        resource = resources.first
+        @logger.info("Running diff for following resource #{resource.id}")
+      end
+
+      # We want to diff resources 1-by-1 for readability
+      resources.each do |r|
+        run_string = ColorizedString.new("Running diff on #{r.type} #{r.namespace}.#{r.name}:").green
+        @logger.blank_line
+        @logger.info(run_string)
+        output, err, diff_st = kubectl.run("diff", "-f", r.file_path, log_failure: true, fail_expected: true)
+
+        if output.blank?
+          no_diff_string = ColorizedString.new("Local and cluster versions are identical").yellow
+          @logger.info(no_diff_string)
+        end
+
+        # Kubectl DIFF currently spits out exit code 1 in all cases - PR to customize that is open
+        # https://github.com/kubernetes/kubernetes/pull/82336
+        # next if diff_st.success?
+        # raise FatalDeploymentError, <<~MSG
+        #   Failed to replace or create resource: #{r.id}
+        #   #{err}
+        # MSG
+        stream.puts output
+      end
+    end
+  end
+end

--- a/lib/kubernetes-deploy/diff_task.rb
+++ b/lib/kubernetes-deploy/diff_task.rb
@@ -47,10 +47,9 @@ module KubernetesDeploy
 
     def initialize(
       namespace:, context:, current_sha:, logger: nil, kubectl_instance: nil, bindings: {},
-      selector: nil, template_paths: [], template_dir: nil
+      selector: nil, template_paths: ["."]
     )
-      template_dir = File.expand_path(template_dir) if template_dir
-      template_paths = (template_paths.map { |path| File.expand_path(path) } << template_dir).compact
+      template_paths = (template_paths.map { |path| File.expand_path(path) }).compact
 
       @logger = logger || KubernetesDeploy::FormattedLogger.build(namespace, context)
       @template_sets = TemplateSets.from_dirs_and_files(paths: template_paths, logger: @logger)

--- a/lib/kubernetes-deploy/kubectl.rb
+++ b/lib/kubernetes-deploy/kubectl.rb
@@ -26,7 +26,8 @@ module KubernetesDeploy
     end
 
     def run(*args, log_failure: nil, use_context: true, use_namespace: true, output: nil,
-      raise_if_not_found: false, attempts: 1, output_is_sensitive: nil, retry_whitelist: nil)
+      raise_if_not_found: false, attempts: 1, output_is_sensitive: nil, retry_whitelist: nil,
+      fail_expected: false)
       log_failure = @log_failure_by_default if log_failure.nil?
       output_is_sensitive = @output_is_sensitive_default if output_is_sensitive.nil?
       cmd = build_command_from_options(args, use_namespace, use_context, output)
@@ -37,7 +38,7 @@ module KubernetesDeploy
         out, err, st = Open3.capture3(*cmd)
         @logger.debug("Kubectl out: " + out.gsub(/\s+/, ' ')) unless output_is_sensitive
 
-        break if st.success?
+        break if st.success? || fail_expected
         raise(ResourceNotFoundError, err) if err.match(ERROR_MATCHERS[:not_found]) && raise_if_not_found
 
         if log_failure

--- a/test/fixtures/hello-cloud/configmap-data-diff.yml
+++ b/test/fixtures/hello-cloud/configmap-data-diff.yml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: hello-cloud-configmap-data
+  labels:
+    name: hello-cloud-configmap-data
+    app: hello-cloud
+data:
+  datapoint1: value1
+  datapoint2: value2
+  datapoint3: value3

--- a/test/integration/diff_task_test.rb
+++ b/test/integration/diff_task_test.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+require 'integration_test_helper'
+require 'kubernetes-deploy/diff_task'
+
+class DiffTaskTest < KubernetesDeploy::IntegrationTest
+  def test_no_diff
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "redis.yml"]))
+
+    diff = build_diff_task(
+      fixture_files_path("hello-cloud", files: ["configmap-data.yml", "redis.yml"])
+    )
+    assert_diff_success(diff.run(stream: mock_output_stream))
+
+    assert_logs_match_all([
+      "Running diff for following resources:",
+      "ConfigMap/hello-cloud-configmap-data",
+      /Running diff on ConfigMap .*hello-cloud-configmap-data/,
+      "Local and cluster versions are identical"
+      ],in_order: true
+    )
+  end
+
+  def test_diff
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "redis.yml"]))
+
+    diff = build_diff_task(
+      fixture_files_path("hello-cloud", files: ["configmap-data-diff.yml", "redis.yml"])
+    )
+    assert_diff_success(diff.run(stream: mock_output_stream))
+
+    stdout_assertion do |output|
+      assert_match("+  datapoint3: value3", output)
+    end
+  end
+
+  private
+
+  def build_diff_task(template_paths, bindings = {})
+    KubernetesDeploy::DiffTask.new(
+      namespace: @namespace,
+      context: KubeclientHelper::TEST_CONTEXT,
+      current_sha: "123",
+      template_paths: template_paths,
+      bindings: bindings,
+      logger: logger
+    )
+  end
+end

--- a/test/integration/diff_task_test.rb
+++ b/test/integration/diff_task_test.rb
@@ -29,7 +29,7 @@ class DiffTaskTest < KubernetesDeploy::IntegrationTest
     assert_diff_success(diff.run(stream: mock_output_stream))
 
     stdout_assertion do |output|
-      assert_match("+  datapoint3: value3", output)
+      assert_match("datapoint3: value3", output)
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -127,6 +127,7 @@ module KubernetesDeploy
     end
     alias_method :assert_restart_success, :assert_deploy_success
     alias_method :assert_task_run_success, :assert_deploy_success
+    alias_method :assert_diff_success, :assert_deploy_success
 
     def assert_logs_match(regexp, times = nil)
       logging_assertion do |logs|
@@ -185,6 +186,14 @@ module KubernetesDeploy
       raise ArgumentError,
         "Fixture set #{set_name} does not exist as directory #{source_dir}" unless File.directory?(source_dir)
       source_dir
+    end
+
+    def fixture_files_path(set_name, files: [])
+      fixtures = []
+      files.each do |file|
+        fixtures << fixture_path(set_name) + "/" + file
+      end
+      fixtures
     end
 
     def stub_kubectl_response(*args, kwargs: {}, resp:, err: "", success: true, json: true, times: 1)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
This PR implements `kubectl diff` functionality to both older `kubernetes-deploy` version as `kubernetes-diff` as well as to the new and fancy `krane`.
We are currently running slightly modified version of `kubernetes-deploy` with very minor custom changes, but this is a completely new feature, therefore it would be great to get it properly contributed into upstream.

Examples:
`kubernetes-diff` with default `diff` command
<img width="1439" alt="1" src="https://user-images.githubusercontent.com/6074297/65293387-19880f00-db29-11e9-8710-1f51a006ef81.png">

`kubernetes-diff` with custom `diff` command
<img width="1440" alt="2" src="https://user-images.githubusercontent.com/6074297/65293412-3290c000-db29-11e9-9bcf-a56249c9a618.png">

`krane diff` with default `diff` command
<img width="1440" alt="3" src="https://user-images.githubusercontent.com/6074297/65293445-45a39000-db29-11e9-9b4e-6c772131771c.png">

-----------

**How is this accomplished?**
By applying enormous amount of focus and discipline to click-clacking on the keyboard while your 3y old is running around, singing very loud and trying to force you into writing bugs.

**What could go wrong?**
Mr T. could win 2020 election.
