### PR TITLE
Fix deprecated ejson secret annotation prefix

### DIFF
--- a/lib/kubernetes-deploy/ejson_secret_provisioner.rb
+++ b/lib/kubernetes-deploy/ejson_secret_provisioner.rb
@@ -12,7 +12,7 @@ module KubernetesDeploy
   end
 
   class EjsonSecretProvisioner
-    EJSON_SECRET_ANNOTATION = "kubernetes-deploy.shopify.io/ejson-secret"
+    EJSON_SECRET_ANNOTATION = "krane.shopify.io/ejson-secret"
     EJSON_SECRET_KEY = "kubernetes_secrets"
     EJSON_SECRETS_FILE = "secrets.ejson"
     EJSON_KEYS_SECRET = "ejson-keys"


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

`kubernetes-deploy` is generating ejson secrets with the deprecated annotation, this clears up noise in deploy logs which the user can't fix:

```
[INFO][2019-10-10 09:09:06 +0000]	Template warning: Secret-shopify-build-environment-secrets20191010-854063-91nkb7.yml
[INFO][2019-10-10 09:09:06 +0000]	> Warning message:
[INFO][2019-10-10 09:09:06 +0000]	    kubernetes-deploy.shopify.io as a prefix for annotations is deprecated: Use the 'krane.shopify.io' annotation prefix instead
```

As far as I can tell this annotation isn't actually _read_ or searched for by kubernetes-deploy, in which case backwards compatibility is not a concern. Am I right?