### PR TITLE
Add resource cache prewarm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 *Bug Fixes*
 - Fix a bug causing secret generation from ejson to fail when decryption succeeded but a warning was also emitted. [#647](https://github.com/Shopify/krane/pull/647)
 
+*Enhancements*
+- Warm the ResourceCache before running resource.sync to improve sync performance. ([#603](https://github.com/Shopify/kubernetes-deploy/pull/603))
+
 # 1.0.0
 
 We've renamed the gem and cli to Krane.

--- a/lib/krane/concurrency.rb
+++ b/lib/krane/concurrency.rb
@@ -3,11 +3,11 @@ module Krane
   module Concurrency
     MAX_THREADS = 8
 
-    def self.split_across_threads(all_work, &block)
+    def self.split_across_threads(all_work, max_threads: MAX_THREADS, &block)
       return if all_work.empty?
       raise ArgumentError, "Block of work is required" unless block_given?
 
-      slice_size = ((all_work.length + MAX_THREADS - 1) / MAX_THREADS)
+      slice_size = ((all_work.length + max_threads - 1) / max_threads)
       threads = []
       all_work.each_slice(slice_size) do |work_group|
         threads << Thread.new { work_group.each(&block) }

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -216,6 +216,7 @@ module Krane
 
     def check_initial_status(resources)
       cache = ResourceCache.new(@task_config)
+      cache.prewarm(resources)
       Krane::Concurrency.split_across_threads(resources) { |r| r.sync(cache) }
       resources.each { |r| @logger.info(r.pretty_status) }
     end

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -202,6 +202,7 @@ module Krane
 
     def check_initial_status(resources)
       cache = ResourceCache.new(@task_config)
+      cache.prewarm(resources)
       Concurrency.split_across_threads(resources) { |r| r.sync(cache) }
       resources.each { |r| logger.info(r.pretty_status) }
     end

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -38,6 +38,7 @@ module Krane
     LAST_APPLIED_ANNOTATION = "kubectl.kubernetes.io/last-applied-configuration"
     SENSITIVE_TEMPLATE_CONTENT = false
     SERVER_DRY_RUNNABLE = false
+    SYNC_DEPENDENCIES = []
 
     class << self
       def build(namespace: nil, context:, definition:, logger:, statsd_tags:, crd: nil, global_names: [])

--- a/lib/krane/kubernetes_resource/cloudsql.rb
+++ b/lib/krane/kubernetes_resource/cloudsql.rb
@@ -2,6 +2,7 @@
 module Krane
   class Cloudsql < KubernetesResource
     TIMEOUT = 10.minutes
+    SYNC_DEPENDENCIES = %w(Deployment Service)
 
     def sync(cache)
       super

--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -3,6 +3,7 @@ require "krane/kubernetes_resource/pod_set_base"
 module Krane
   class DaemonSet < PodSetBase
     TIMEOUT = 5.minutes
+    SYNC_DEPENDENCIES = %w(Pod)
     attr_reader :pods
 
     def sync(cache)

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -4,6 +4,7 @@ require 'krane/kubernetes_resource/replica_set'
 module Krane
   class Deployment < KubernetesResource
     TIMEOUT = 7.minutes
+    SYNC_DEPENDENCIES = %w(Pod ReplicaSet)
     REQUIRED_ROLLOUT_ANNOTATION_SUFFIX = "required-rollout"
     REQUIRED_ROLLOUT_ANNOTATION_DEPRECATED = "kubernetes-deploy.shopify.io/#{REQUIRED_ROLLOUT_ANNOTATION_SUFFIX}"
     REQUIRED_ROLLOUT_ANNOTATION = "krane.shopify.io/#{REQUIRED_ROLLOUT_ANNOTATION_SUFFIX}"

--- a/lib/krane/kubernetes_resource/service.rb
+++ b/lib/krane/kubernetes_resource/service.rb
@@ -4,16 +4,12 @@ require 'krane/kubernetes_resource/pod'
 module Krane
   class Service < KubernetesResource
     TIMEOUT = 7.minutes
+    SYNC_DEPENDENCIES = %w(Pod Deployment StatefulSet)
 
     def sync(cache)
       super
-      if exists? && selector.present?
-        @related_pods = cache.get_all(Pod.kind, selector)
-        @related_workloads = fetch_related_workloads(cache)
-      else
-        @related_pods = []
-        @related_workloads = []
-      end
+      @related_pods = cache.get_all(Pod.kind, selector)
+      @related_workloads = fetch_related_workloads(cache)
     end
 
     def status

--- a/lib/krane/kubernetes_resource/stateful_set.rb
+++ b/lib/krane/kubernetes_resource/stateful_set.rb
@@ -4,6 +4,7 @@ module Krane
   class StatefulSet < PodSetBase
     TIMEOUT = 10.minutes
     ONDELETE = 'OnDelete'
+    SYNC_DEPENDENCIES = %w(Pod)
     attr_reader :pods
 
     def sync(cache)

--- a/lib/krane/resource_cache.rb
+++ b/lib/krane/resource_cache.rb
@@ -36,6 +36,12 @@ module Krane
       []
     end
 
+    def prewarm(resources)
+      sync_dependencies = resources.flat_map { |r| r.class.const_get(:SYNC_DEPENDENCIES) }
+      kinds = (resources.map(&:type) + sync_dependencies).uniq
+      Krane::Concurrency.split_across_threads(kinds, max_threads: kinds.count) { |kind| get_all(kind) }
+    end
+
     private
 
     def statsd_tags

--- a/lib/krane/resource_watcher.rb
+++ b/lib/krane/resource_watcher.rb
@@ -53,6 +53,7 @@ module Krane
 
     def sync_resources(resources)
       cache = ResourceCache.new(@task_config)
+      cache.prewarm(resources)
       Krane::Concurrency.split_across_threads(resources) { |r| r.sync(cache) }
       resources.each(&:after_sync)
     end

--- a/test/helpers/cluster_resource_discovery_helper.rb
+++ b/test/helpers/cluster_resource_discovery_helper.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+module ClusterResourceDiscoveryHelper
+  def mocked_cluster_resource_discovery(response, success: true, namespaced: false)
+    Krane::Kubectl.any_instance.stubs(:run)
+      .with("api-resources", "--namespaced=#{namespaced}", attempts: 5, use_namespace: false, output: "wide")
+      .returns([response, "", stub(success?: success)])
+    Krane::ClusterResourceDiscovery.new(task_config: task_config, namespace_tags: [])
+  end
+
+  def api_versions_full_response
+    File.read(File.join(fixture_path('for_unit_tests'), "api_versions.txt"))
+  end
+
+  def api_resources_namespaced_full_response
+    File.read(File.join(fixture_path('for_unit_tests'), "api_resources_namespaced.txt"))
+  end
+
+  def api_resources_not_namespaced_full_response
+    File.read(File.join(fixture_path('for_unit_tests'), "api_resources_global.txt"))
+  end
+end

--- a/test/helpers/mock_resource.rb
+++ b/test/helpers/mock_resource.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 MockResource = Struct.new(:id, :hits_to_complete, :status) do
+  self::SYNC_DEPENDENCIES = []
+  self::SENSITIVE_TEMPLATE_CONTENT = false
+
   def debug_message(*)
     @debug_message
   end

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -2,6 +2,8 @@
 require 'test_helper'
 
 class ClusterResourceDiscoveryTest < Krane::TestCase
+  include ClusterResourceDiscoveryHelper
+
   def test_fetch_resources_failure
     crd = mocked_cluster_resource_discovery(nil, success: false)
     resources = crd.fetch_resources
@@ -51,26 +53,5 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     %w(ConfigMap CronJob Deployment).each do |expected_kind|
       assert kinds.one? { |k| k.include?(expected_kind) }
     end
-  end
-
-  private
-
-  def mocked_cluster_resource_discovery(response, success: true, namespaced: false)
-    Krane::Kubectl.any_instance.stubs(:run)
-      .with("api-resources", "--namespaced=#{namespaced}", attempts: 5, use_namespace: false, output: "wide")
-      .returns([response, "", stub(success?: success)])
-    Krane::ClusterResourceDiscovery.new(task_config: task_config, namespace_tags: [])
-  end
-
-  def api_versions_full_response
-    File.read(File.join(fixture_path('for_unit_tests'), "api_versions.txt"))
-  end
-
-  def api_resources_namespaced_full_response
-    File.read(File.join(fixture_path('for_unit_tests'), "api_resources_namespaced.txt"))
-  end
-
-  def api_resources_not_namespaced_full_response
-    File.read(File.join(fixture_path('for_unit_tests'), "api_resources_global.txt"))
   end
 end

--- a/test/unit/krane/kubernetes_resource/deployment_test.rb
+++ b/test/unit/krane/kubernetes_resource/deployment_test.rb
@@ -283,6 +283,7 @@ class DeploymentTest < Krane::TestCase
   end
 
   def test_deploy_succeeded_not_fooled_by_stale_status_data
+    stub_kind_get("Pod")
     deployment_status = {
       "replicas" => 3,
       "updatedReplicas" => 3, # stale -- hasn't been updated since deploy

--- a/test/unit/krane/kubernetes_resource/replica_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/replica_set_test.rb
@@ -23,26 +23,6 @@ class ReplicaSetTest < Krane::TestCase
     refute_predicate(rs, :deploy_failed?)
   end
 
-  def test_sync_does_not_request_pods_if_we_already_know_they_are_fine
-    should_fetch = build_rs_template(status: { "readyReplicas": 1, "observedGeneration": 2 })
-    should_not_fetch = build_rs_template(status: { "readyReplicas": 2, "observedGeneration": 2 })
-
-    rs = Krane::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: should_fetch)
-    stub_kind_get("ReplicaSet", items: [should_fetch])
-    stub_kind_get("Pod", items: [])
-    rs.sync(build_resource_cache)
-
-    stub_kind_get("ReplicaSet", items: [should_not_fetch])
-    rs.sync(build_resource_cache)
-  end
-
-  def test_sync_does_not_request_pods_if_desired_replicas_is_zero
-    template = build_rs_template
-    template["status"] = { "observedGeneration": 2 }
-    template["spec"]["replicas"] = 0
-    build_synced_rs(template: template) # does not stub pod get
-  end
-
   private
 
   def build_rs_template(status: {})
@@ -50,6 +30,7 @@ class ReplicaSetTest < Krane::TestCase
   end
 
   def build_synced_rs(template:)
+    stub_kind_get("Pod")
     rs = Krane::ReplicaSet.new(namespace: "test", context: "nope", logger: logger, definition: template)
     stub_kind_get("ReplicaSet", items: [template])
     rs.sync(build_resource_cache)

--- a/test/unit/krane/kubernetes_resource/service_test.rb
+++ b/test/unit/krane/kubernetes_resource/service_test.rb
@@ -9,6 +9,9 @@ class ServiceTest < Krane::TestCase
     svc = build_service(svc_def)
 
     stub_kind_get("Service", items: [])
+    stub_kind_get("Pod", times: 2)
+    stub_kind_get("Deployment", times: 2)
+    stub_kind_get("StatefulSet", times: 2)
     svc.sync(build_resource_cache)
     refute(svc.exists?)
     refute(svc.deploy_succeeded?)
@@ -26,6 +29,7 @@ class ServiceTest < Krane::TestCase
     svc = build_service(svc_def)
 
     stub_kind_get("Service", items: [svc_def])
+    %w(Pod Deployment StatefulSet).each { |kind| stub_kind_get(kind) }
     svc.sync(build_resource_cache)
     assert(svc.exists?)
     assert(svc.deploy_succeeded?)
@@ -40,6 +44,7 @@ class ServiceTest < Krane::TestCase
     ]
 
     stub_kind_get("Service", items: [])
+    %w(Pod Deployment StatefulSet).each { |kind| stub_kind_get(kind) }
     cache = build_resource_cache
     all_services.each { |svc| svc.sync(cache) }
 

--- a/test/unit/krane/resource_watcher_test.rb
+++ b/test/unit/krane/resource_watcher_test.rb
@@ -2,6 +2,8 @@
 require 'test_helper'
 
 class ResourceWatcherTest < Krane::TestCase
+  include ResourceCacheTestHelper
+
   def test_requires_enumerable
     expected_msg = "ResourceWatcher expects Enumerable collection, got `Object` instead"
     assert_raises_message(ArgumentError, expected_msg) do
@@ -12,6 +14,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_success_with_mock_resource_and_summary_recording_enabled
+    stub_kind_get("MockResource")
     resource = build_mock_resource
 
     watcher = build_watcher([resource])
@@ -26,6 +29,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_success_with_mock_resource_and_summary_recording_disabled
+    stub_kind_get("MockResource")
     resource = build_mock_resource
 
     watcher = build_watcher([resource])
@@ -38,6 +42,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_failure_with_mock_resource
+    stub_kind_get("MockResource")
     resource = build_mock_resource(final_status: "failed")
 
     watcher = build_watcher([resource])
@@ -53,6 +58,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_timeout_from_resource
+    stub_kind_get("MockResource")
     resource = build_mock_resource(final_status: "timeout")
 
     watcher = build_watcher([resource])
@@ -62,6 +68,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_wait_logging_when_resources_do_not_finish_together
+    stub_kind_get("MockResource", times: 4)
     first = build_mock_resource(final_status: "success", hits_to_complete: 1, name: "first")
     second = build_mock_resource(final_status: "timeout", hits_to_complete: 2, name: "second")
     third = build_mock_resource(final_status: "failed", hits_to_complete: 3, name: "third")
@@ -82,6 +89,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_reminder_logged_at_interval_even_when_nothing_happened
+    stub_kind_get("MockResource", times: 9)
     resource1 = build_mock_resource(final_status: "success", hits_to_complete: 1, name: 'first')
     resource2 = build_mock_resource(final_status: "success", hits_to_complete: 9, name: 'second')
     resource3 = build_mock_resource(final_status: "success", hits_to_complete: 9, name: 'third')
@@ -98,6 +106,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_timeout_allows_success
+    stub_kind_get("MockResource")
     resource = build_mock_resource(hits_to_complete: 1)
     watcher = Krane::ResourceWatcher.new(resources: [resource],
       timeout: 2, task_config: task_config(namespace: 'test'))
@@ -107,6 +116,7 @@ class ResourceWatcherTest < Krane::TestCase
   end
 
   def test_timeout_raises_after_timeout_seconds
+    stub_kind_get("MockResource", times: 3)
     resource = build_mock_resource(hits_to_complete: 10**100)
     watcher = Krane::ResourceWatcher.new(resources: [resource],
       timeout: 0.02, task_config: task_config(namespace: 'test'))

--- a/test/unit/krane/resource_watcher_test.rb
+++ b/test/unit/krane/resource_watcher_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 
 class ResourceWatcherTest < Krane::TestCase
   include ResourceCacheTestHelper
+  include ClusterResourceDiscoveryHelper
 
   def test_requires_enumerable
     expected_msg = "ResourceWatcher expects Enumerable collection, got `Object` instead"
@@ -15,6 +16,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_success_with_mock_resource_and_summary_recording_enabled
     stub_kind_get("MockResource")
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource = build_mock_resource
 
     watcher = build_watcher([resource])
@@ -30,6 +32,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_success_with_mock_resource_and_summary_recording_disabled
     stub_kind_get("MockResource")
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource = build_mock_resource
 
     watcher = build_watcher([resource])
@@ -43,6 +46,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_failure_with_mock_resource
     stub_kind_get("MockResource")
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource = build_mock_resource(final_status: "failed")
 
     watcher = build_watcher([resource])
@@ -59,6 +63,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_timeout_from_resource
     stub_kind_get("MockResource")
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource = build_mock_resource(final_status: "timeout")
 
     watcher = build_watcher([resource])
@@ -69,6 +74,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_wait_logging_when_resources_do_not_finish_together
     stub_kind_get("MockResource", times: 4)
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     first = build_mock_resource(final_status: "success", hits_to_complete: 1, name: "first")
     second = build_mock_resource(final_status: "timeout", hits_to_complete: 2, name: "second")
     third = build_mock_resource(final_status: "failed", hits_to_complete: 3, name: "third")
@@ -90,6 +96,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_reminder_logged_at_interval_even_when_nothing_happened
     stub_kind_get("MockResource", times: 9)
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource1 = build_mock_resource(final_status: "success", hits_to_complete: 1, name: 'first')
     resource2 = build_mock_resource(final_status: "success", hits_to_complete: 9, name: 'second')
     resource3 = build_mock_resource(final_status: "success", hits_to_complete: 9, name: 'third')
@@ -107,6 +114,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_timeout_allows_success
     stub_kind_get("MockResource")
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource = build_mock_resource(hits_to_complete: 1)
     watcher = Krane::ResourceWatcher.new(resources: [resource],
       timeout: 2, task_config: task_config(namespace: 'test'))
@@ -117,6 +125,7 @@ class ResourceWatcherTest < Krane::TestCase
 
   def test_timeout_raises_after_timeout_seconds
     stub_kind_get("MockResource", times: 3)
+    mocked_cluster_resource_discovery(api_resources_namespaced_full_response)
     resource = build_mock_resource(hits_to_complete: 10**100)
     watcher = Krane::ResourceWatcher.new(resources: [resource],
       timeout: 0.02, task_config: task_config(namespace: 'test'))


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Resolve https://github.com/Shopify/kubernetes-deploy/issues/591
Warm up the resource cache before running `resource.sync` by populating it with various kinds that we know we'll need.

**How is this accomplished?**

- Similar to the suggestion in the linked issue, `use_or_populate_cache(kind)` on each kind before the `sync` step.
- I came up with which kinds to prefetch and when by looking at each sync method. There's a chance I overlooked something so let me know.
- I tested it by assuring the method that does the warming was making kubectl calls to both a resource (deployment) and its listed prefetch kinds (in this case, pods).

**What could go wrong?**

- I might have missed something
- This doesn't improve things how we/I thought it would