### PR TITLE
WIP: Add a watch command

### DIFF
--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -8,6 +8,7 @@ require 'krane/cli/run_command'
 require 'krane/cli/render_command'
 require 'krane/cli/deploy_command'
 require 'krane/cli/global_deploy_command'
+require 'krane/cli/watch_command'
 
 module Krane
   module CLI
@@ -64,6 +65,14 @@ module Krane
       def global_deploy(context)
         rescue_and_exit do
           GlobalDeployCommand.from_options(context, options)
+        end
+      end
+
+      desc("watch NAMESPACE CONTEXT", "Watch the namespace and sync all the resources")
+      expand_options(WatchCommand::OPTIONS)
+      def watch(namespace, context)
+        rescue_and_exit do
+          WatchCommand.from_options(namespace, context, options)
         end
       end
 

--- a/lib/krane/cli/watch_command.rb
+++ b/lib/krane/cli/watch_command.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+module Krane
+  module CLI
+    class WatchCommand
+      DEFAULT_WATCH_TIMEOUT = '300s'
+
+      OPTIONS = {
+        "filenames" => { type: :array, banner: 'config/deploy/my_rendered_templates.yml',
+                         aliases: :f, required: true,
+                         desc: "The path to a set of rendered kubernetes templates" },
+        "global-timeout" => {
+          type: :string,
+          banner: "duration",
+          desc: "Timeout error is raised if the pod runs for longer than the specified number of seconds",
+          default: DEFAULT_WATCH_TIMEOUT,
+        },
+      }
+
+      def self.from_options(namespace, context, options)
+        require 'krane/watch_task'
+        require 'krane/options_helper'
+
+        ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames],
+          require_explicit_path: true) do |paths|
+          watcher = ::Krane::WatchTask.new(
+            namespace: namespace,
+            context: context,
+            filenames: paths,
+            max_watch_seconds: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
+          )
+
+          watcher.run!
+        end
+      end
+    end
+  end
+end

--- a/lib/krane/watch_task.rb
+++ b/lib/krane/watch_task.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+require 'krane/common'
+require 'krane/cluster_resource_discovery'
+
+module Krane
+  class WatchTask
+    include TemplateReporting
+    delegate :namespace, :context, :logger, to: :@task_config
+
+    def initialize(namespace:, context:, filenames: [], max_watch_seconds: nil)
+      template_paths = filenames.map { |path| File.expand_path(path) }
+
+      @task_config = TaskConfig.new(context, namespace)
+      @template_sets = TemplateSets.from_dirs_and_files(paths: template_paths, logger: @task_config.logger)
+      @max_watch_seconds = max_watch_seconds
+    end
+
+    def run(*args)
+      run!(*args)
+      true
+    rescue FatalDeploymentError
+      false
+    end
+
+    def run!(*_args)
+      resources = discover_resources
+      watcher = ResourceWatcher.new(
+        resources: resources,
+        task_config: @task_config,
+        operation_name: 'sync',
+        timeout: @max_watch_seconds,
+      )
+      watcher.run
+    end
+
+    private
+
+    def discover_resources
+      logger.info("Discovering resources:")
+      resources = []
+      crds_by_kind = cluster_resource_discoverer.crds.map { |crd| [crd.name, crd] }.to_h
+      @template_sets.with_resource_definitions do |definition|
+        crd = crds_by_kind[definition["kind"]]&.first
+        resource = KubernetesResource.build(namespace: namespace, context: context, logger: logger, definition: definition,
+          crd: crd, statsd_tags: statsd_tags)
+        resources << resource
+        logger.info("  - #{resource.id}")
+      end
+
+      resources.sort
+    rescue InvalidTemplateError => e
+      record_invalid_template(logger: logger, err: e.message, filename: e.filename, content: e.content)
+      raise FatalDeploymentError, "Failed to parse template"
+    end
+
+    def statsd_tags
+      %W(context:#{context} namespace:#{namespace})
+    end
+
+    def cluster_resource_discoverer
+      @cluster_resource_discoverer ||= ClusterResourceDiscovery.new(task_config: @task_config)
+    end
+  end
+end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

I'll be out for a little bit so putting this up as a WIP / draft for anyone to hack on or 👀 

- Add a `krane watch` command as a non-destructive way to do resource syncs. To be honest, mostly to test that https://github.com/Shopify/kubernetes-deploy/pull/603 does what I want it to.

**How is this accomplished?**

New CLI command, rely on resourcewatcher. Danny's recent global PR has some handy code too that I wanted to nab.
This WIP is very hacky. I haven't had a chance to clean it up at all or add tests.

**What could go wrong?**

It could not work I guess. It should be non-destructive so.