### PR TITLE
Remove rendering from krane deploy

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -10,7 +10,7 @@ module Krane
         kube-public
       )
       OPTIONS = {
-        "filenames" => { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
+        "filenames" => { type: :string, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                          aliases: :f, required: true,
                          desc: "Directories and files that contains the configuration to apply" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
@@ -27,8 +27,6 @@ module Krane
                                   default: true },
         "verify-result" => { type: :boolean, default: true,
                              desc: "Verify workloads correctly deployed" },
-        "current-sha" => { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
-
       }
 
       def self.from_options(namespace, context, options)
@@ -46,12 +44,11 @@ module Krane
           protected_namespaces = []
         end
 
-        ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames],
+        ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames].split,
           require_explicit_path: true) do |paths|
           deploy = ::Krane::DeployTask.new(
             namespace: namespace,
             context: context,
-            current_sha: options['current-sha'],
             template_paths: paths,
             logger: logger,
             max_watch_seconds: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -10,7 +10,7 @@ module Krane
         kube-public
       )
       OPTIONS = {
-        "filenames" => { type: :string, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
+        "filenames" => { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                          aliases: :f, required: true,
                          desc: "Directories and files that contains the configuration to apply" },
         "global-timeout" => { type: :string, banner: "duration", default: DEFAULT_DEPLOY_TIMEOUT,
@@ -44,7 +44,7 @@ module Krane
           protected_namespaces = []
         end
 
-        ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames].split,
+        ::Krane::OptionsHelper.with_processed_template_paths(options[:filenames],
           require_explicit_path: true) do |paths|
           deploy = ::Krane::DeployTask.new(
             namespace: namespace,

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -10,9 +10,6 @@ module Krane
         kube-public
       )
       OPTIONS = {
-        "bindings" => { type: :array, banner: "foo=bar abc=def",
-                        desc: "Expose additional variables to ERB templates (format: k1=v1 k2=v2, JSON string or file "\
-                          "(JSON or YAML) path prefixed by '@')" },
         "filenames" => { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                          aliases: :f, required: true,
                          desc: "Directories and files that contains the configuration to apply" },
@@ -24,7 +21,6 @@ module Krane
                                     default: PROTECTED_NAMESPACES },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that do not appear in the template dir",
                      default: true },
-        "render-erb" => { type: :boolean, desc: "Enable ERB rendering", default: false },
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
@@ -38,11 +34,7 @@ module Krane
       def self.from_options(namespace, context, options)
         require 'krane/deploy_task'
         require 'krane/options_helper'
-        require 'krane/bindings_parser'
         require 'krane/label_selector'
-
-        bindings_parser = ::Krane::BindingsParser.new
-        options[:bindings]&.each { |binding_pair| bindings_parser.add(binding_pair) }
 
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
 
@@ -61,7 +53,6 @@ module Krane
             context: context,
             current_sha: options['current-sha'],
             template_paths: paths,
-            bindings: bindings_parser.parse,
             logger: logger,
             max_watch_seconds: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,

--- a/lib/krane/cli/render_command.rb
+++ b/lib/krane/cli/render_command.rb
@@ -7,7 +7,8 @@ module Krane
         bindings: { type: :array, banner: "foo=bar abc=def", desc: 'Bindings for erb' },
         filenames: { type: :array, banner: 'config/deploy/production config/deploy/my-extra-resource.yml',
                      required: true, aliases: 'f', desc: 'Directories and files to render' },
-        'current-sha': { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings" },
+        'current-sha': { type: :string, banner: "SHA", desc: "Expose SHA `current_sha` in ERB bindings",
+                         lazy_default: '' },
       }
 
       def self.from_options(options)

--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -128,6 +128,10 @@ module Krane
 
       errors += template_sets.validate
 
+      if !@current_sha.nil? && @current_sha.empty?
+        errors << "current-sha is optional but can not be blank"
+      end
+
       unless errors.empty?
         @logger.summary.add_action("Configuration invalid")
         @logger.summary.add_paragraph(errors.map { |err| "- #{err}" }.join("\n"))

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -11,11 +11,10 @@ module Krane
     delegate :logger, to: :@task_config
     attr_reader :statsd_tags
 
-    def initialize(task_config:, prune_whitelist:, max_watch_seconds:, current_sha: nil, selector:, statsd_tags:)
+    def initialize(task_config:, prune_whitelist:, max_watch_seconds:, selector:, statsd_tags:)
       @task_config = task_config
       @prune_whitelist = prune_whitelist
       @max_watch_seconds = max_watch_seconds
-      @current_sha = current_sha
       @selector = selector
       @statsd_tags = statsd_tags
     end
@@ -119,7 +118,7 @@ module Krane
 
       if verify
         watcher = Krane::ResourceWatcher.new(resources: resources, deploy_started_at: deploy_started_at,
-          timeout: @max_watch_seconds, task_config: @task_config, sha: @current_sha)
+          timeout: @max_watch_seconds, task_config: @task_config)
         watcher.run(record_summary: record_summary)
       end
     end

--- a/lib/krane/resource_watcher.rb
+++ b/lib/krane/resource_watcher.rb
@@ -9,7 +9,7 @@ module Krane
     delegate :namespace, :context, :logger, to: :@task_config
 
     def initialize(resources:, task_config:, deploy_started_at: Time.now.utc,
-      operation_name: "deploy", timeout: nil, sha: nil)
+      operation_name: "deploy", timeout: nil)
       unless resources.is_a?(Enumerable)
         raise ArgumentError, <<~MSG
           ResourceWatcher expects Enumerable collection, got `#{resources.class}` instead
@@ -20,7 +20,6 @@ module Krane
       @deploy_started_at = deploy_started_at
       @operation_name = operation_name
       @timeout = timeout
-      @sha = sha
     end
 
     def run(delay_sync: 3.seconds, reminder_interval: 30.seconds, record_summary: true)
@@ -62,7 +61,6 @@ module Krane
       {
         namespace: namespace,
         context: context,
-        sha: @sha,
       }
     end
 

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 require 'test_helper'
 require 'krane/cli/krane'
-require 'krane/bindings_parser'
 
 class DeployTest < Krane::TestCase
   def test_deploy_with_default_options
@@ -21,16 +20,6 @@ class DeployTest < Krane::TestCase
     Krane::LabelSelector.expects(:parse).returns(selector)
     set_krane_deploy_expectations(new_args: { selector: selector })
     krane_deploy!(flags: '--selector name:web')
-  end
-
-  def test_deploy_parses_bindings
-    bindings_parser = Krane::BindingsParser.new
-    bindings_parser.expects(:add).with('foo=bar')
-    bindings_parser.expects(:add).with('abc=def')
-    bindings_parser.expects(:parse).returns(true)
-    Krane::BindingsParser.expects(:new).returns(bindings_parser)
-    set_krane_deploy_expectations(new_args: { bindings: true })
-    krane_deploy!(flags: '--bindings foo=bar abc=def')
   end
 
   def test_deploy_passes_verify_result
@@ -79,12 +68,6 @@ class DeployTest < Krane::TestCase
     end
   end
 
-  def test_deploy_uses_current_sha
-    test_sha = "TEST"
-    set_krane_deploy_expectations(new_args: { current_sha: test_sha })
-    krane_deploy!(flags: "--current-sha #{test_sha}")
-  end
-
   private
 
   def set_krane_deploy_expectations(new_args: {}, run_args: {})
@@ -113,9 +96,7 @@ class DeployTest < Krane::TestCase
       new_args: {
         namespace: deploy_task_config.namespace,
         context: deploy_task_config.context,
-        current_sha: nil,
         template_paths: ['/tmp'],
-        bindings: {},
         logger: logger,
         max_watch_seconds: 300,
         selector: nil,

--- a/test/exe/render_test.rb
+++ b/test/exe/render_test.rb
@@ -48,7 +48,7 @@ class RendertTest < Krane::TestCase
 
   def default_options(new_args = {})
     {
-      current_sha: ENV["REVISION"],
+      current_sha: nil,
       template_paths: ["/dev/null"],
       bindings: {},
     }.merge(new_args)

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -58,7 +58,7 @@ module FixtureDeployHelper
     success
   end
 
-  def deploy_raw_fixtures(set, wait: true, bindings: {}, subset: nil, render_erb: false)
+  def deploy_raw_fixtures(set, wait: true, subset: nil)
     success = false
     if subset
       Dir.mktmpdir("fixture_dir") do |target_dir|
@@ -70,31 +70,28 @@ module FixtureDeployHelper
         subset.each do |file|
           FileUtils.copy_entry(File.join(fixture_path(set), file), File.join(target_dir, file))
         end
-        success = deploy_dirs(target_dir, wait: wait, bindings: bindings, render_erb: render_erb)
+        success = deploy_dirs(target_dir, wait: wait)
       end
     else
-      success = deploy_dirs(fixture_path(set), wait: wait, bindings: bindings, render_erb: render_erb)
+      success = deploy_dirs(fixture_path(set), wait: wait)
     end
     success
   end
 
-  def deploy_dirs_without_profiling(dirs, wait: true, allow_protected_ns: false, prune: true, bindings: {},
-    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, max_watch_seconds: nil, selector: nil,
-    protected_namespaces: nil, render_erb: false, allow_globals: true)
+  def deploy_dirs_without_profiling(dirs, wait: true, allow_protected_ns: false, prune: true,
+    kubectl_instance: nil, max_watch_seconds: nil, selector: nil,
+    protected_namespaces: nil, allow_globals: true)
     kubectl_instance ||= build_kubectl
 
     deploy = KubernetesDeploy::DeployTask.new(
       namespace: @namespace,
-      current_sha: sha,
       context: KubeclientHelper::TEST_CONTEXT,
       template_paths: dirs,
       logger: logger,
       kubectl_instance: kubectl_instance,
-      bindings: bindings,
       max_watch_seconds: max_watch_seconds,
       selector: selector,
       protected_namespaces: protected_namespaces,
-      render_erb: render_erb,
       allow_globals: allow_globals
     )
     deploy.run(

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -296,7 +296,7 @@ class SerialDeployTest < Krane::IntegrationTest
 
   def test_all_expected_statsd_metrics_emitted_with_essential_tags
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = deploy_fixtures('hello-cloud', subset: ['configmap-data.yml'], wait: false, sha: 'test-sha')
+      result = deploy_fixtures('hello-cloud', subset: ['configmap-data.yml'], wait: false)
       assert_deploy_success(result)
     end
 
@@ -317,7 +317,6 @@ class SerialDeployTest < Krane::IntegrationTest
       refute_nil metric, "Metric #{expected_metric} not emitted"
       assert_includes metric.tags, "namespace:#{@namespace}", "#{metric.name} is missing namespace tag"
       assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
-      assert_includes metric.tags, "sha:test-sha", "#{metric.name} is missing sha tag"
     end
   end
 

--- a/test/integration/krane_test.rb
+++ b/test/integration/krane_test.rb
@@ -52,6 +52,14 @@ class KraneTest < Krane::IntegrationTest
     assert_match(test_sha, out)
   end
 
+  def test_render_current_sha_cant_be_blank
+    paths = ["test/fixtures/test-partials/partials/independent-configmap.yml.erb"]
+    _, err, status = krane_black_box("render", "-f #{paths.join(' ')} --current-sha")
+    refute_predicate(status, :success?)
+    assert_match("FAILURE", err)
+    assert_match("current-sha is optional but can not be blank", err)
+  end
+
   def test_deploy_black_box_success
     render_out, _, render_status = krane_black_box("render",
       "-f #{fixture_path('hello-cloud')} --bindings deployment_id=1 current_sha=123")

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -377,6 +377,19 @@ class RenderTaskTest < Krane::TestCase
     end
   end
 
+  def test_render_errors_empty_sha
+    render = Krane::RenderTask.new(logger: logger, current_sha: "", bindings: {},
+      template_dir: fixture_path('test-partials'))
+    fixture = 'deployment.yaml.erb'
+
+    assert_render_failure(render.run(mock_output_stream, [fixture]))
+    assert_logs_match_all([
+      "Result: FAILURE",
+      "Configuration invalid",
+      "- current-sha is optional but can not be blank",
+    ], in_order: true)
+  end
+
   private
 
   def build_render_task(template_dir, bindings = {})

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -4,8 +4,7 @@ require 'krane/restart_task'
 
 class RestartTaskTest < Krane::IntegrationTest
   def test_restart_by_annotation
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"],
-      render_erb: true))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
     refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
@@ -31,12 +30,10 @@ class RestartTaskTest < Krane::IntegrationTest
   def test_restart_by_selector
     assert_deploy_success(deploy_fixtures("branched",
       bindings: { "branch" => "master" },
-      selector: Krane::LabelSelector.parse("branch=master"),
-      render_erb: true))
+      selector: Krane::LabelSelector.parse("branch=master")))
     assert_deploy_success(deploy_fixtures("branched",
       bindings: { "branch" => "staging" },
-      selector: Krane::LabelSelector.parse("branch=staging"),
-      render_erb: true))
+      selector: Krane::LabelSelector.parse("branch=staging")))
 
     refute(fetch_restarted_at("master-web"), "no RESTARTED_AT env on fresh deployment")
     refute(fetch_restarted_at("staging-web"), "no RESTARTED_AT env on fresh deployment")
@@ -72,8 +69,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_restart_named_deployments_twice
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
-      render_erb: true))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
 
@@ -104,8 +100,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_restart_with_same_resource_twice
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
-      render_erb: true))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
 
@@ -136,7 +131,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_restart_one_not_existing_deployment
-    assert(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"], render_erb: true))
+    assert(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]))
 
     restart = build_restart_task
     assert_restart_failure(restart.perform(%w(walrus web)))
@@ -199,8 +194,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_restart_failure
-    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
-      render_erb: true) do |fixtures|
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       deployment["spec"]["progressDeadlineSeconds"] = 30
       container = deployment["spec"]["template"]["spec"]["containers"].first
@@ -237,7 +231,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_restart_successful_with_partial_availability
-    result = deploy_fixtures("slow-cloud", render_erb: true) do |fixtures|
+    result = deploy_fixtures("slow-cloud") do |fixtures|
       web = fixtures["web.yml.erb"]["Deployment"].first
       web["spec"]["strategy"]['rollingUpdate']['maxUnavailable'] = '50%'
       container = web["spec"]["template"]["spec"]["containers"].first
@@ -267,8 +261,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_verify_result_false_succeeds
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"],
-      render_erb: true))
+    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb", "redis.yml"]))
 
     refute(fetch_restarted_at("web"), "no RESTARTED_AT env on fresh deployment")
     refute(fetch_restarted_at("redis"), "no RESTARTED_AT env on fresh deployment")
@@ -300,8 +293,7 @@ class RestartTaskTest < Krane::IntegrationTest
   end
 
   def test_verify_result_false_succeeds_quickly_when_verification_would_timeout
-    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"],
-      render_erb: true) do |fixtures|
+    success = deploy_fixtures("hello-cloud", subset: ["configmap-data.yml", "web.yml.erb"]) do |fixtures|
       deployment = fixtures["web.yml.erb"]["Deployment"].first
       deployment["spec"]["progressDeadlineSeconds"] = 30
       container = deployment["spec"]["template"]["spec"]["containers"].first

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -228,9 +228,9 @@ module Krane
       @task_config ||= Krane::TaskConfig.new(context, namespace, logger)
     end
 
-    def krane_black_box(command, args = "")
+    def krane_black_box(command, args = "", stdin_data: '')
       path = File.expand_path("../../exe/krane", __FILE__)
-      Open3.capture3("#{path} #{command} #{args}")
+      Open3.capture3("#{path} #{command} #{args}", stdin_data: stdin_data)
     end
 
     private

--- a/test/unit/krane/deploy_task_test.rb
+++ b/test/unit/krane/deploy_task_test.rb
@@ -17,7 +17,6 @@ class DeployTaskTest < Krane::TestCase
       namespace: "something",
       context: KubeclientHelper::TEST_CONTEXT,
       logger: logger,
-      current_sha: "",
       template_paths: ["unknown"],
     ).run
     assert_logs_match("Configuration invalid")

--- a/test/unit/krane/kubernetes_resource/horizontal_pod_autoscaler_test.rb
+++ b/test/unit/krane/kubernetes_resource/horizontal_pod_autoscaler_test.rb
@@ -10,7 +10,7 @@ class HorizontalPodAutoscalerTest < Krane::TestCase
       .with("get", "CustomResourceDefinition", output: "json", attempts: 5, use_namespace: false)
       .returns(['{ "items": [] }', "", SystemExit.new(0)])
     task = Krane::DeployTask.new(namespace: 'test', context: KubeclientHelper::TEST_CONTEXT,
-      current_sha: 'foo', template_paths: [''], logger: logger)
+      template_paths: [''], logger: logger)
     assert(task.prune_whitelist.one? { |whitelisted_type| whitelisted_type.include?("HorizontalPodAutoscaler") })
   end
 

--- a/test/unit/krane/resource_deployer_test.rb
+++ b/test/unit/krane/resource_deployer_test.rb
@@ -88,9 +88,8 @@ class ResourceDeployerTest < Krane::TestCase
     unless kubectl_times == 0
       Krane::Kubectl.expects(:new).returns(build_runless_kubectl).times(kubectl_times)
     end
-    @deployer = Krane::ResourceDeployer.new(current_sha: 'test-sha',
-      statsd_tags: [], task_config: task_config, prune_whitelist: prune_whitelist,
-      max_watch_seconds: 1, selector: nil)
+    @deployer = Krane::ResourceDeployer.new(statsd_tags: [], task_config: task_config,
+      prune_whitelist: prune_whitelist, max_watch_seconds: 1, selector: nil)
   end
 
   def build_mock_resource(final_status: "success", hits_to_complete: 0, name: "web-pod")

--- a/test/unit/krane/template_sets_test.rb
+++ b/test/unit/krane/template_sets_test.rb
@@ -57,8 +57,7 @@ class TemplateSetsTest < Krane::TestCase
     template_sets = template_sets_from_paths(*paths)
 
     file_names = []
-    template_sets.with_resource_definitions_and_filename(render_erb: true,
-     bindings: { data: "1" }) do |rendered_content, filename|
+    template_sets.with_resource_definitions_and_filename(bindings: { data: "1" }) do |rendered_content, filename|
       file_names << filename
       refute_empty rendered_content
     end
@@ -66,8 +65,7 @@ class TemplateSetsTest < Krane::TestCase
 
     file_names = []
     assert_raises(Krane::InvalidTemplateError) do
-      template_sets.with_resource_definitions_and_filename(render_erb: true,
-       bindings: {}) do |rendered_content, filename|
+      template_sets.with_resource_definitions_and_filename(bindings: {}) do |rendered_content, filename|
         file_names << filename
         refute_empty rendered_content
       end

--- a/test/unit/krane/template_sets_test.rb
+++ b/test/unit/krane/template_sets_test.rb
@@ -57,7 +57,8 @@ class TemplateSetsTest < Krane::TestCase
     template_sets = template_sets_from_paths(*paths)
 
     file_names = []
-    template_sets.with_resource_definitions_and_filename(bindings: { data: "1" }) do |rendered_content, filename|
+    template_sets.with_resource_definitions_and_filename(render_erb: true,
+      bindings: { data: "1" }) do |rendered_content, filename|
       file_names << filename
       refute_empty rendered_content
     end
@@ -65,7 +66,8 @@ class TemplateSetsTest < Krane::TestCase
 
     file_names = []
     assert_raises(Krane::InvalidTemplateError) do
-      template_sets.with_resource_definitions_and_filename(bindings: {}) do |rendered_content, filename|
+      template_sets.with_resource_definitions_and_filename(render_erb: true,
+        bindings: {}) do |rendered_content, filename|
         file_names << filename
         refute_empty rendered_content
       end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Remove the ability of `krane deploy` to render erb

**How is this accomplished?**
Remove the flags, remove the args to new/run, fix the tests.

**What could go wrong?**
- current-sha gets fed to statsd tags, we could leave the flag just for that, but I'd rather add an explicit flag for extra statsd tags if desired. 

- Make the migration to krane 1.0 harder. 
