### PR TITLE
Fix links to prerequisites sections in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,11 +54,11 @@ If you need the ability to render dynamic values in templates before deploying, 
 * [Usage](#usage-2)
 
 **KRANE RUN**
-* [Prerequisites](#prerequisites-2)
+* [Prerequisites](#prerequisites-1)
 * [Usage](#usage-3)
 
 **KRANE RENDER**
-* [Prerequisites](#prerequisites-3)
+* [Prerequisites](#prerequisites-2)
 * [Usage](#usage-4)
 
 **CONTRIBUTING**


### PR DESCRIPTION
Before, the link in the table of contents to the `krane run` prerequisites linked to the `krane render` prerequisites, and the `krane render` prerequisites link was broken.

**What are you trying to accomplish with this PR?**
Fix links in README.

**How is this accomplished?**
Changing the links.

**What could go wrong?**
The links could be wrong.
