### PR TITLE
[doc fix] remove old deploy render flag references

### DIFF
--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -126,8 +126,7 @@ Old flag | New flag | Comments
 -h, --help | -h, --help |
 -v, --version | [none] | Replaced with `krane version`
 $ENVIRONMENT | [none] | Dropped in favour of `-f`
-$REVISION | --current-sha | The environment variable REVISION was dropped in favour of an explicit flag
-[none] | --render-erb | **Important:** the new CLI doesn't render ERB by default
+$REVISION | [none] | The environment variable REVISION was dropped because deploy no longer renders.
 [none] | --stdin | Allow template filenames given from stdin stream
 
 #### krane restart


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Update migration guide to be accurate

**How is this accomplished?**
Remove references to flags that were removed before 1.0

**What could go wrong?**
Just a doc update. 
