### PR TITLE
Mark kubectl-sourced strings with invalid encoding as UTF-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Bug Fixes*
+- Help ruby correctly identify kubectl output encoding. [#646](https://github.com/Shopify/krane/pull/646)
+
 ## 1.1.1
 
 *Enhancements*

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -36,7 +36,7 @@ module Krane
         out, err, st = Open3.capture3(*cmd)
 
         # https://github.com/Shopify/krane/issues/395
-        if out.encoding != Encoding::UTF_8
+        unless out.valid_encoding?
           out = out.dup.force_encoding(Encoding::UTF_8)
         end
 

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -348,6 +348,16 @@ class KubectlTest < Krane::TestCase
     end
   end
 
+  def test_debug_level_output_log_uses_correct_encoding
+    logger.level = ::Logger::DEBUG
+    good = "hélas"
+    bad = good.dup.force_encoding(Encoding::US_ASCII)
+
+    stub_open3(%W(kubectl get pods --namespace=testn --context=testc --request-timeout=#{timeout}), resp: bad)
+    out, _err, _st = build_kubectl.run("get", "pods")
+    assert_equal good, out
+  end
+
   private
 
   def timeout

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -348,14 +348,27 @@ class KubectlTest < Krane::TestCase
     end
   end
 
-  def test_debug_level_output_log_uses_correct_encoding
+  def test_kubectl_run_fixes_encoding_when_locales_set_to_non_utf8
+    ext_before = Encoding.default_external
+    int_before = Encoding.default_internal
     logger.level = ::Logger::DEBUG
-    good = "hélas"
-    bad = good.dup.force_encoding(Encoding::US_ASCII)
+    utf8 = "こんにちは！hélas!"
 
-    stub_open3(%W(kubectl get pods --namespace=testn --context=testc --request-timeout=#{timeout}), resp: bad)
+    # This is how setting the env from https://github.com/Shopify/krane/issues/395 manifests internally
+    Encoding.default_external = Encoding::US_ASCII
+    Encoding.default_internal = nil
+
+    # put the string through the default external encoder
+    data = %x(echo #{utf8})
+    assert_equal(Encoding::US_ASCII, data.encoding)
+
+    stub_open3(%W(kubectl get pods --namespace=testn --context=testc --request-timeout=#{timeout}), resp: data)
     out, _err, _st = build_kubectl.run("get", "pods")
-    assert_equal good, out
+    assert_equal(utf8, out)
+    assert_equal(Encoding::UTF_8, out.encoding)
+  ensure
+    Encoding.default_external = ext_before
+    Encoding.default_internal = int_before
   end
 
   private


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fixes #395 for good.

**How is this accomplished?**
* We know that kubectl is returning utf-8 encoded strings, so if Ruby has interpreted them otherwise, correct it. 
* Only do the gsub when we're going to use the result.

**What could go wrong?**
* I don't have much experience working with encodings, so if this solution is weird, call me out!
