### PR TITLE
Exclude stderr from parsing on decryption success

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Bug Fixes*
+- Fix a bug causing secret generation from ejson to fail when decryption succeeded but a warning was also emitted. [#647](https://github.com/Shopify/krane/pull/647)
+
 # 1.0.0
 
 We've renamed the gem and cli to Krane.

--- a/lib/krane/ejson_secret_provisioner.rb
+++ b/lib/krane/ejson_secret_provisioner.rb
@@ -134,10 +134,13 @@ module Krane
     end
 
     def decrypt_ejson(key_dir)
-      # ejson seems to dump both errors and output to STDOUT
-      out_err, st = Open3.capture2e("EJSON_KEYDIR=#{key_dir} ejson decrypt #{@ejson_file}")
-      raise EjsonSecretError, out_err unless st.success?
-      JSON.parse(out_err)
+      out, err, st = Open3.capture3("EJSON_KEYDIR=#{key_dir} ejson decrypt #{@ejson_file}")
+      unless st.success?
+        # older ejson versions dump some errors to STDOUT
+        msg = err.presence || out
+        raise EjsonSecretError, msg
+      end
+      JSON.parse(out)
     rescue JSON::ParserError
       raise EjsonSecretError, "Failed to parse decrypted ejson"
     end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fixes https://github.com/Shopify/krane/issues/643. The underlying problem seems to be that we're reading stdout and stderr together. There are cases when successful ejson decryption returns both a warning (on stderr) and the result (on stdout), so unsurprisingly the combination of the two cannot be parsed. The reason we were doing this is because older versions of ejson printed many (all?) errors to stdout. https://github.com/Shopify/ejson/pull/44 fixed this in version 1.2, but I'd prefer to continue supporting ejson 1.0, to avoid subjecting ruby consumers to dependency conflicts.

**How is this accomplished?**
Read stdout and stderr separately, but if decryption failed, manually check stdout for the error message to accommodate older ejson versions.

**What could go wrong?**
If ever ejson exits non-zero yet prints something decrypted to either stream, we'll also print it. This would not be new, however, and I've never heard a report of it happening.