### PR TITLE
Delete storageclass at end of test

### DIFF
--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -691,6 +691,8 @@ class SerialDeployTest < Krane::IntegrationTest
       %r{Pod could not be scheduled because 0/\d+ nodes are available:},
       /\d+ node[(]s[)] didn't find available persistent volumes to bind./,
     ], in_order: true)
+  ensure
+    storage_v1_kubeclient.delete_storage_class(storage_class_name)
   end
 
   private


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix a resource leak from a test. You can see this test was the culprit from the output of the other test (which shouldn't be pruning anything):

```
[INFO][2019-12-03 22:23:23 +0000]   
[INFO][2019-12-03 22:23:23 +0000]   ------------------------------------Phase 1: Initializing deploy ------------------------------------ 
[INFO][2019-12-03 22:23:23 +0000]   Using resource selector app=krane
[INFO][2019-12-03 22:23:23 +0000]   All required parameters and files are present
[INFO][2019-12-03 22:23:23 +0000]   Discovering resources:
[INFO][2019-12-03 22:23:24 +0000]     - Namespace/test-app
[INFO][2019-12-03 22:23:24 +0000]     - StorageClass/testing-storage-class
[INFO][2019-12-03 22:23:24 +0000]     - PriorityClass/testing-priority-class
[INFO][2019-12-03 22:23:24 +0000]   
[INFO][2019-12-03 22:23:24 +0000]   ----------------------------Phase 2: Checking initial resource statuses ----------------------------- 
[INFO][2019-12-03 22:23:24 +0000]   Namespace/test-app                                Not Found
[INFO][2019-12-03 22:23:24 +0000]   PriorityClass/testing-priority-class              Not Found
[INFO][2019-12-03 22:23:24 +0000]   StorageClass/testing-storage-class                Not Found
[INFO][2019-12-03 22:23:24 +0000]   
[INFO][2019-12-03 22:23:24 +0000]   ----------------------------------Phase 3: Deploying all resources ---------------------------------- 
[INFO][2019-12-03 22:23:24 +0000]   Deploying resources:
[INFO][2019-12-03 22:23:24 +0000]   - Namespace/test-app (timeout: 300s)
[INFO][2019-12-03 22:23:24 +0000]   - PriorityClass/testing-priority-class (timeout: 300s)
[INFO][2019-12-03 22:23:24 +0000]   - StorageClass/testing-storage-class (timeout: 300s)
[INFO][2019-12-03 22:23:25 +0000]   The following resources were pruned: storageclass.storage.k8s.io/k8s-deploy-test-no-pv
[WARN][2019-12-03 22:23:25 +0000]    Don't know how to monitor resources of type Namespace. Assuming Namespace/test-app deployed successfully.
 [WARN][2019-12-03 22:23:25 +0000]   Don't know how to monitor resources of type PriorityClass. Assuming PriorityClass/testing-priority-class deployed successfully.
 [WARN][2019-12-03 22:23:25 +0000]   Don't know how to monitor resources of type StorageClass. Assuming StorageClass/testing-storage-class deployed successfully.
 [INFO][2019-12-03 22:23:25 +0000]    Successfully deployed in 0.9s:  Namespace/test-app, PriorityClass/testing-priority-class, StorageClass/testing-storage-class
[INFO][2019-12-03 22:23:25 +0000]   
[INFO][2019-12-03 22:23:25 +0000]   ------------------------------------------Result:  SUCCESS ------------------------------------------- 
[INFO][2019-12-03 22:23:25 +0000]   Pruned 1 resource and successfully deployed 3 resources
[INFO][2019-12-03 22:23:25 +0000]   
[INFO][2019-12-03 22:23:25 +0000]   Successful resources 
[INFO][2019-12-03 22:23:25 +0000]   Namespace/test-app                                Exists
[INFO][2019-12-03 22:23:25 +0000]   PriorityClass/testing-priority-class              Exists
[INFO][2019-12-03 22:23:25 +0000]   StorageClass/testing-storage-class                Exists 
```

**How is this accomplished?**
Deleting in an `ensure`.

**What could go wrong?**
Not much.
