### PR TITLE
Scope all global fixture deploys

### DIFF
--- a/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -20,7 +20,7 @@ Style/Alias:
   - prefer_alias
   - prefer_alias_method
 
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: ignore_implicit
@@ -30,7 +30,7 @@ Layout/AlignHash:
   - ignore_implicit
   - ignore_explicit
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
   SupportedStyles:
   - with_first_parameter
@@ -172,7 +172,7 @@ Naming/FileName:
   Regex:
   IgnoreExecutableScripts: true
 
-Layout/IndentFirstArgument:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - consistent
@@ -225,7 +225,7 @@ Layout/IndentationConsistency:
 Layout/IndentationWidth:
   Width: 2
 
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -233,10 +233,10 @@ Layout/IndentFirstArrayElement:
   - align_brackets
   IndentationWidth:
 
-Layout/IndentAssignment:
+Layout/AssignmentIndentation:
   IndentationWidth:
 
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
   SupportedStyles:
   - special_inside_parentheses
@@ -340,9 +340,9 @@ Style/PercentQLiterals:
 Naming/PredicateName:
   NamePrefix:
   - is_
-  NamePrefixBlacklist:
+  ForbiddenPrefixes:
   - is_
-  NameWhitelist:
+  AllowedMethods:
   - is_a?
   Exclude:
   - 'spec/**/*'
@@ -467,7 +467,7 @@ Style/TernaryParentheses:
   - require_no_parentheses
   AllowSafeAssignment: true
 
-Layout/TrailingBlankLines:
+Layout/TrailingEmptyLines:
   EnforcedStyle: final_newline
   SupportedStyles:
   - final_newline
@@ -478,7 +478,7 @@ Style/TrivialAccessors:
   AllowPredicates: true
   AllowDSLWriters: false
   IgnoreClassMethods: false
-  Whitelist:
+  AllowedMethods:
   - to_ary
   - to_a
   - to_c
@@ -561,7 +561,7 @@ Lint/UnusedMethodArgument:
 Naming/AccessorMethodName:
   Enabled: true
 
-Layout/AlignArray:
+Layout/ArrayAlignment:
   Enabled: true
 
 Style/ArrayJoin:
@@ -840,7 +840,7 @@ Style/WhileUntilDo:
 Style/ZeroLengthPredicate:
   Enabled: true
 
-Layout/IndentHeredoc:
+Layout/HeredocIndentation:
   EnforcedStyle: squiggly
 
 Lint/AmbiguousOperator:
@@ -864,7 +864,7 @@ Lint/DeprecatedClassMethods:
 Lint/DuplicateMethods:
   Enabled: true
 
-Lint/DuplicatedKey:
+Lint/DuplicateHashKey:
   Enabled: true
 
 Lint/EachWithObjectArgument:
@@ -891,7 +891,7 @@ Lint/FloatOutOfRange:
 Lint/FormatParameterMismatch:
   Enabled: true
 
-Lint/HandleExceptions:
+Lint/SuppressedException:
   AllowComments: true
 
 Lint/ImplicitStringConcatenation:
@@ -947,7 +947,7 @@ Lint/ShadowedException:
 Lint/ShadowingOuterLocalVariable:
   Enabled: true
 
-Lint/StringConversionInInterpolation:
+Lint/RedundantStringCoercion:
   Enabled: true
 
 Lint/UnderscorePrefixedVariableName:

--- a/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,3 +1,5 @@
+# Recommended rubocop version: ~> 0.78.0
+
 AllCops:
   Exclude:
   - 'db/schema.rb'
@@ -509,7 +511,7 @@ Style/WhileUntilModifier:
 Metrics/BlockNesting:
   Max: 3
 
-Metrics/LineLength:
+Layout/LineLength:
   Max: 120
   AllowHeredoc: true
   AllowURI: true

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,15 +3,3 @@ inherit_from:
 
 AllCops:
   TargetRubyVersion: 2.4
-
-Naming/FileName:
-  Enabled: true
-  Exclude:
-    - lib/krane.rb
-
-Sorbet/ConstantsFromStrings:
-  Enabled: false
-
-Layout/Tab:
-  Exclude:
-    - test/integration/krane_deploy_test.rb

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -54,6 +54,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("byebug")
   spec.add_development_dependency("ruby-prof")
   spec.add_development_dependency("ruby-prof-flamegraph")
-  spec.add_development_dependency("rubocop", "~> 0.76.0")
+  spec.add_development_dependency("rubocop", "~> 0.78.0")
   spec.add_development_dependency("codecov")
 end

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -53,7 +53,7 @@ module FixtureDeployHelper
 
     target_dir = Dir.mktmpdir("fixture_dir")
     write_fixtures_to_dir(fixtures, target_dir)
-    @global_fixtures_deployed << target_dir
+    @deployed_global_fixture_paths << target_dir
 
     deploy = Krane::GlobalDeployTask.new(
       context: KubeclientHelper::TEST_CONTEXT,
@@ -190,7 +190,7 @@ module FixtureDeployHelper
             # metadata.name has to be composed this way for CRDs
             resource["metadata"]["name"] = "#{resource['spec']['names']['plural']}.#{resource['spec']['group']}"
           else
-            resource["metadata"]["name"] = add_unique_prefix_for_test(resource["metadata"]["name"])[0..63]
+            resource["metadata"]["name"] = add_unique_prefix_for_test(resource["metadata"]["name"])[0..253]
           end
         end
       end

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -3,75 +3,7 @@ require 'integration_test_helper'
 
 class SerialDeployTest < Krane::IntegrationTest
   include StatsD::Instrument::Assertions
-  # This cannot be run in parallel because it either stubs a constant or operates in a non-exclusive namespace
-  def test_deploying_to_protected_namespace_with_override_does_not_prune
-    assert_deploy_success(deploy_fixtures("hello-cloud", subset: ['configmap-data.yml', 'disruption-budgets.yml'],
-      protected_namespaces: [@namespace], prune: false))
-    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
-    hello_cloud.assert_configmap_data_present
-    hello_cloud.assert_poddisruptionbudget
-    assert_logs_match_all([
-      /cannot be pruned/,
-      /Please do not deploy to #{@namespace} unless you really know what you are doing/,
-    ])
-
-    result = deploy_fixtures("hello-cloud", subset: ["disruption-budgets.yml"],
-      protected_namespaces: [@namespace], prune: false)
-    assert_deploy_success(result)
-    hello_cloud.assert_configmap_data_present # not pruned
-    hello_cloud.assert_poddisruptionbudget
-  end
-
-  # This cannot be run in parallel because it needs to manipulate the global log level
-  def test_create_secrets_from_ejson
-    logger.level = ::Logger::DEBUG # for assertions that we don't log secret data
-
-    # Create secrets
-    ejson_cloud = FixtureSetAssertions::EjsonCloud.new(@namespace)
-    ejson_cloud.create_ejson_keys_secret
-    assert_deploy_success(deploy_fixtures("ejson-cloud"))
-    ejson_cloud.assert_all_up
-    assert_logs_match_all([
-      %r{Secret\/catphotoscom\s+Available},
-      %r{Secret\/unused-secret\s+Available},
-      %r{Secret\/monitoring-token\s+Available},
-    ])
-
-    refute_logs_match(ejson_cloud.test_private_key)
-    refute_logs_match(ejson_cloud.test_public_key)
-    refute_logs_match(Base64.strict_encode64(ejson_cloud.catphotoscom_key_value))
-  end
-
-  def test_sensitive_output_suppressed_when_creating_secret_with_generate_name
-    logger.level = ::Logger::DEBUG # for assertions that we don't log secret data
-
-    # Create secrets
-    result = deploy_fixtures("generateName", subset: "secret.yml")
-    secret_name = /generate-name-secret-[a-z0-9]{5}/
-    assert_deploy_success(result)
-    assert_logs_match_all([
-      'Deploying Secret/generate-name-secret-',
-      'Successfully deployed 1 resource',
-      %r{Secret/#{secret_name}\s+Available},
-    ], in_order: true)
-
-    refute_logs_match("cGFzc3dvcmQ=")
-  end
-
-  def test_sensitive_output_suppressed_when_creating_secret_with_generate_name_fails
-    logger.level = ::Logger::DEBUG # for assertions that we don't log secret data
-
-    # Create secrets
-    result = deploy_fixtures("generateName", subset: "bad_secret.yml")
-    assert_deploy_failure(result)
-    assert_logs_match_all([
-      'Failed to replace or create resource: secret/generate-name-secret-',
-      "<suppressed sensitive output>",
-    ], in_order: true)
-
-    refute_logs_match("cGFzc3dvcmQ=")
-  end
-
+  ## GLOBAL CONTEXT MANIPULATION TESTS
   # This can be run in parallel if we allow passing the config file path to DeployTask.new
   # See https://github.com/Shopify/krane/pull/428#pullrequestreview-209720675
   def test_unreachable_context
@@ -122,6 +54,166 @@ class SerialDeployTest < Krane::IntegrationTest
     ENV['KUBECONFIG'] = old_config
   end
 
+  # We want to be sure that failures to apply resources with potentially sensitive output don't leak any content.
+  # Currently our only sensitive resource is `Secret`, but we cannot reproduce a failure scenario where the kubectl
+  # output contains the filename (which would trigger some extra logging). This test stubs `Deployment` to be sensitive
+  # to recreate such a condition
+  def test_apply_failure_with_sensitive_resources_hides_template_content
+    logger.level = 0
+    Krane::Deployment.any_instance.expects(:sensitive_template_content?).returns(true).at_least_once
+    result = deploy_fixtures("hello-cloud", subset: ["web.yml.erb"], render_erb: true) do |fixtures|
+      bad_port_name = "http_test_is_really_long_and_invalid_chars"
+      svc = fixtures["web.yml.erb"]["Service"].first
+      svc["spec"]["ports"].first["targetPort"] = bad_port_name
+      deployment = fixtures["web.yml.erb"]["Deployment"].first
+      deployment["spec"]["template"]["spec"]["containers"].first["ports"].first["name"] = bad_port_name
+    end
+    assert_deploy_failure(result)
+    refute_logs_match(%r{Kubectl err:.*something/invalid})
+
+    assert_logs_match_all([
+      "Command failed: apply -f",
+      /Invalid template: Deployment-web.*\.yml/,
+    ])
+
+    refute_logs_match("kind: Deployment") # content of the sensitive template
+  end
+
+  ## METRICS TESTS
+  # Metrics tests must be run serially to ensure our global client isn't capturing metrics from other tests
+  def test_stage_related_metrics_include_custom_tags_from_namespace
+    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
+    kubeclient.patch_namespace(hello_cloud.namespace, metadata: { labels: { foo: 'bar' } })
+    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+      assert_deploy_success deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"], wait: false)
+    end
+
+    %w(
+      Krane.validate_configuration.duration
+      Krane.discover_resources.duration
+      Krane.validate_resources.duration
+      Krane.initial_status.duration
+      Krane.priority_resources.duration
+      Krane.apply_all.duration
+      Krane.normal_resources.duration
+      Krane.all_resources.duration
+    ).each do |expected_metric|
+      metric = metrics.find { |m| m.name == expected_metric }
+      refute_nil metric, "Metric #{expected_metric} not emitted"
+      assert_includes metric.tags, "foo:bar", "Metric #{expected_metric} did not have custom tags"
+    end
+  end
+
+  def test_all_expected_statsd_metrics_emitted_with_essential_tags
+    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+      result = deploy_fixtures('hello-cloud', subset: ['configmap-data.yml'], wait: false, sha: 'test-sha')
+      assert_deploy_success(result)
+    end
+
+    assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
+
+    %w(
+      Krane.validate_configuration.duration
+      Krane.discover_resources.duration
+      Krane.initial_status.duration
+      Krane.validate_resources.duration
+      Krane.priority_resources.duration
+      Krane.apply_all.duration
+      Krane.normal_resources.duration
+      Krane.sync.duration
+      Krane.all_resources.duration
+    ).each do |expected_metric|
+      metric = metrics.find { |m| m.name == expected_metric }
+      refute_nil metric, "Metric #{expected_metric} not emitted"
+      assert_includes metric.tags, "namespace:#{@namespace}", "#{metric.name} is missing namespace tag"
+      assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
+      assert_includes metric.tags, "sha:test-sha", "#{metric.name} is missing sha tag"
+    end
+  end
+
+  def test_global_deploy_emits_expected_statsd_metrics
+    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+      assert_deploy_success(deploy_global_fixtures('globals'))
+    end
+
+    assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
+
+    %w(
+      Krane.validate_configuration.duration
+      Krane.discover_resources.duration
+      Krane.initial_status.duration
+      Krane.validate_resources.duration
+      Krane.apply_all.duration
+      Krane.normal_resources.duration
+      Krane.sync.duration
+      Krane.all_resources.duration
+    ).each do |expected_metric|
+      metric = metrics.find { |m| m.name == expected_metric }
+      refute_nil metric, "Metric #{expected_metric} not emitted"
+      assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
+    end
+  end
+
+  ## BLACK BOX TESTS
+  # test_global_deploy_black_box_failure is in test/integration/krane_test.rb
+  # because it does not modify global state. The following two tests modify
+  # global state and must be run in serially
+  def test_global_deploy_black_box_success
+    setup_template_dir("globals") do |target_dir|
+      flags = "-f #{target_dir} --selector app=krane"
+      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
+      assert_empty(out)
+      assert_match("Success", err)
+      assert_predicate(status, :success?)
+    end
+  ensure
+    build_kubectl.run("delete", "-f", fixture_path("globals"), use_namespace: false, log_failure: false)
+  end
+
+  def test_global_deploy_black_box_timeout
+    setup_template_dir("globals") do |target_dir|
+      flags = "-f #{target_dir} --selector app=krane --global-timeout=0.1s"
+      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
+      assert_empty(out)
+      assert_match("TIMED OUT", err)
+      refute_predicate(status, :success?)
+      assert_equal(status.exitstatus, 70)
+    end
+  ensure
+    build_kubectl.run("delete", "-f", fixture_path("globals"), use_namespace: false, log_failure: false)
+  end
+
+  def test_global_deploy_prune_black_box_success
+    namespace_name = "test-app"
+    setup_template_dir("globals") do |target_dir|
+      flags = "-f #{target_dir} --selector app=krane"
+      namespace_str = "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: #{namespace_name}"\
+      "\n  labels:\n    app: krane"
+      File.write(File.join(target_dir, "namespace.yml"), namespace_str)
+      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
+      assert_empty(out)
+      assert_match("Successfully deployed 3 resource", err)
+      assert_match(/#{namespace_name}\W+Exists/, err)
+      assert_match("Success", err)
+      assert_predicate(status, :success?)
+
+      flags = "-f #{target_dir}/storage_classes.yml --selector app=krane"
+      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
+      assert_empty(out)
+      refute_match(namespace_name, err) # Asserting that the namespace is not pruned
+      assert_match("Pruned 1 resource and successfully deployed 1 resource", err)
+      assert_predicate(status, :success?)
+    end
+  ensure
+    build_kubectl.run("delete", "-f", fixture_path("globals"), use_namespace: false, log_failure: false)
+    build_kubectl.run("delete", "namespace", namespace_name, use_namespace: false, log_failure: false)
+  end
+
+  ## TESTS THAT DEPLOY CRDS
+  # Tests that create CRDs cannot be run in parallel with tests that deploy namespaced resources
+  # This is because the CRD kind may torn down in the middle of the namespaced deploy, causing it to be seen
+  # when we build the pruning whitelist, but gone by the time we attempt to list instances for pruning purposes.
+  # When this happens, the namespaced deploy will fail with an `apply` error.
   def test_cr_merging
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(mail.yml)))
     result = deploy_fixtures("crd", subset: %w(mail_cr.yml)) do |f|
@@ -136,30 +228,6 @@ class SerialDeployTest < Krane::IntegrationTest
       cr["kind"] = add_unique_prefix_for_test(cr["kind"])
     end
     assert_deploy_success(result)
-  end
-
-  def test_crd_can_fail
-    result = deploy_global_fixtures("crd", subset: %(mail.yml)) do |f|
-      crd = f.dig("mail.yml", "CustomResourceDefinition").first
-      names = crd.dig("spec", "names")
-      names["listKind"] = 'Conflict'
-    end
-    assert_deploy_success(result)
-
-    second_name = add_unique_prefix_for_test("others")
-    result = deploy_global_fixtures("crd", subset: %(mail.yml), prune: false) do |f|
-      crd = f.dig("mail.yml", "CustomResourceDefinition").first
-      names = crd.dig("spec", "names")
-      names["listKind"] = "Conflict"
-      names["plural"] = second_name
-      crd["metadata"]["name"] = "#{second_name}.stable.example.io"
-    end
-    assert_deploy_failure(result)
-    assert_logs_match_all([
-      "Deploying CustomResourceDefinition/#{second_name}.stable.example.io (timeout: 120s)",
-      "CustomResourceDefinition/#{second_name}.stable.example.io: FAILED",
-      'Final status: ListKindConflict ("Conflict" is already in use)',
-    ])
   end
 
   def test_custom_resources_predeployed_deprecated
@@ -245,82 +313,9 @@ class SerialDeployTest < Krane::IntegrationTest
     )
   end
 
-  def test_stage_related_metrics_include_custom_tags_from_namespace
-    hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
-    kubeclient.patch_namespace(hello_cloud.namespace, metadata: { labels: { foo: 'bar' } })
-    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      assert_deploy_success deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"], wait: false)
-    end
-
-    %w(
-      Krane.validate_configuration.duration
-      Krane.discover_resources.duration
-      Krane.validate_resources.duration
-      Krane.initial_status.duration
-      Krane.priority_resources.duration
-      Krane.apply_all.duration
-      Krane.normal_resources.duration
-      Krane.all_resources.duration
-    ).each do |expected_metric|
-      metric = metrics.find { |m| m.name == expected_metric }
-      refute_nil metric, "Metric #{expected_metric} not emitted"
-      assert_includes metric.tags, "foo:bar", "Metric #{expected_metric} did not have custom tags"
-    end
-  end
-
-  def test_all_expected_statsd_metrics_emitted_with_essential_tags
-    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = deploy_fixtures('hello-cloud', subset: ['configmap-data.yml'], wait: false, sha: 'test-sha')
-      assert_deploy_success(result)
-    end
-
-    assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
-
-    %w(
-      Krane.validate_configuration.duration
-      Krane.discover_resources.duration
-      Krane.initial_status.duration
-      Krane.validate_resources.duration
-      Krane.priority_resources.duration
-      Krane.apply_all.duration
-      Krane.normal_resources.duration
-      Krane.sync.duration
-      Krane.all_resources.duration
-    ).each do |expected_metric|
-      metric = metrics.find { |m| m.name == expected_metric }
-      refute_nil metric, "Metric #{expected_metric} not emitted"
-      assert_includes metric.tags, "namespace:#{@namespace}", "#{metric.name} is missing namespace tag"
-      assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
-      assert_includes metric.tags, "sha:test-sha", "#{metric.name} is missing sha tag"
-    end
-  end
-
-  def test_global_deploy_emits_expected_statsd_metrics
-    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      assert_deploy_success(deploy_global_fixtures('globals'))
-    end
-
-    assert_equal(1, metrics.count { |m| m.type == :_e }, "Expected to find one event metric")
-
-    %w(
-      Krane.validate_configuration.duration
-      Krane.discover_resources.duration
-      Krane.initial_status.duration
-      Krane.validate_resources.duration
-      Krane.apply_all.duration
-      Krane.normal_resources.duration
-      Krane.sync.duration
-      Krane.all_resources.duration
-    ).each do |expected_metric|
-      metric = metrics.find { |m| m.name == expected_metric }
-      refute_nil metric, "Metric #{expected_metric} not emitted"
-      assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
-    end
-  end
-
   def test_cr_deploys_without_rollout_conditions_when_none_present_deprecated
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(widgets_deprecated.yml)))
-    result = deploy_fixtures("crd", subset: %w(widgets_cr.yml), prune: false) do |fixtures|
+    result = deploy_fixtures("crd", subset: %w(widgets_cr.yml)) do |fixtures|
       cr = fixtures["widgets_cr.yml"]["Widget"].first
       cr["kind"] = add_unique_prefix_for_test(cr["kind"])
     end
@@ -336,7 +331,7 @@ class SerialDeployTest < Krane::IntegrationTest
 
   def test_cr_deploys_without_rollout_conditions_when_none_present
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(widgets.yml)))
-    result = deploy_fixtures("crd", subset: %w(widgets_cr.yml), prune: false) do |f|
+    result = deploy_fixtures("crd", subset: %w(widgets_cr.yml)) do |f|
       f.each do |_filename, contents| # all of the resources are CRs, so change all of them
         contents.each do |_kind, crs|
           crs.each { |cr| cr["kind"] = add_unique_prefix_for_test(cr["kind"]) }
@@ -369,7 +364,7 @@ class SerialDeployTest < Krane::IntegrationTest
       },
     }
 
-    result = deploy_fixtures("crd", subset: ["with_default_conditions_cr.yml"], prune: false) do |resource|
+    result = deploy_fixtures("crd", subset: ["with_default_conditions_cr.yml"]) do |resource|
       cr = resource["with_default_conditions_cr.yml"]["Parameterized"].first
       cr.merge!(success_conditions)
       cr["kind"] = add_unique_prefix_for_test(cr["kind"])
@@ -519,57 +514,28 @@ class SerialDeployTest < Krane::IntegrationTest
     ], in_order: true)
   end
 
-  # We want to be sure that failures to apply resources with potentially sensitive output don't leak any content.
-  # Currently our only sensitive resource is `Secret`, but we cannot reproduce a failure scenario where the kubectl
-  # output contains the filename (which would trigger some extra logging). This test stubs `Deployment` to be sensitive
-  # to recreate such a condition
-  def test_apply_failure_with_sensitive_resources_hides_template_content
-    logger.level = 0
-    Krane::Deployment.any_instance.expects(:sensitive_template_content?).returns(true).at_least_once
-    result = deploy_fixtures("hello-cloud", subset: ["web.yml.erb"], render_erb: true) do |fixtures|
-      bad_port_name = "http_test_is_really_long_and_invalid_chars"
-      svc = fixtures["web.yml.erb"]["Service"].first
-      svc["spec"]["ports"].first["targetPort"] = bad_port_name
-      deployment = fixtures["web.yml.erb"]["Deployment"].first
-      deployment["spec"]["template"]["spec"]["containers"].first["ports"].first["name"] = bad_port_name
+  def test_crd_can_fail
+    result = deploy_global_fixtures("crd", subset: %(mail.yml)) do |f|
+      crd = f.dig("mail.yml", "CustomResourceDefinition").first
+      names = crd.dig("spec", "names")
+      names["listKind"] = 'Conflict'
+    end
+    assert_deploy_success(result)
+
+    second_name = add_unique_prefix_for_test("others")
+    result = deploy_global_fixtures("crd", subset: %(mail.yml), prune: false) do |f|
+      crd = f.dig("mail.yml", "CustomResourceDefinition").first
+      names = crd.dig("spec", "names")
+      names["listKind"] = "Conflict"
+      names["plural"] = second_name
+      crd["metadata"]["name"] = "#{second_name}.stable.example.io"
     end
     assert_deploy_failure(result)
-    refute_logs_match(%r{Kubectl err:.*something/invalid})
-
     assert_logs_match_all([
-      "Command failed: apply -f",
-      /Invalid template: Deployment-web.*\.yml/,
+      "Deploying CustomResourceDefinition/#{second_name}.stable.example.io (timeout: 120s)",
+      "CustomResourceDefinition/#{second_name}.stable.example.io: FAILED",
+      'Final status: ListKindConflict ("Conflict" is already in use)',
     ])
-
-    refute_logs_match("kind: Deployment") # content of the sensitive template
-  end
-
-  # test_global_deploy_black_box_failure is in test/integration/krane_test.rb
-  # because it does not modify global state. The following two tests modify
-  # global state and must be run in serially
-  def test_global_deploy_black_box_success
-    setup_template_dir("globals") do |target_dir|
-      flags = "-f #{target_dir} --selector app=krane"
-      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
-      assert_empty(out)
-      assert_match("Success", err)
-      assert_predicate(status, :success?)
-    end
-  ensure
-    build_kubectl.run("delete", "-f", fixture_path("globals"), use_namespace: false, log_failure: false)
-  end
-
-  def test_global_deploy_black_box_timeout
-    setup_template_dir("globals") do |target_dir|
-      flags = "-f #{target_dir} --selector app=krane --global-timeout=0.1s"
-      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
-      assert_empty(out)
-      assert_match("TIMED OUT", err)
-      refute_predicate(status, :success?)
-      assert_equal(status.exitstatus, 70)
-    end
-  ensure
-    build_kubectl.run("delete", "-f", fixture_path("globals"), use_namespace: false, log_failure: false)
   end
 
   def test_global_deploy_validation_catches_namespaced_cr
@@ -591,151 +557,5 @@ class SerialDeployTest < Krane::IntegrationTest
       "Namespaced resources:",
       "#{add_unique_prefix_for_test('my-first-mail')} (#{add_unique_prefix_for_test('Mail')})",
     ])
-  end
-
-  def test_global_deploy_prune_black_box_success
-    namespace_name = "test-app"
-    setup_template_dir("globals") do |target_dir|
-      flags = "-f #{target_dir} --selector app=krane"
-      namespace_str = "apiVersion: v1\nkind: Namespace\nmetadata:\n  name: #{namespace_name}"\
-      "\n  labels:\n    app: krane"
-      File.write(File.join(target_dir, "namespace.yml"), namespace_str)
-      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
-      assert_empty(out)
-      assert_match("Successfully deployed 3 resource", err)
-      assert_match(/#{namespace_name}\W+Exists/, err)
-      assert_match("Success", err)
-      assert_predicate(status, :success?)
-
-      flags = "-f #{target_dir}/storage_classes.yml --selector app=krane"
-      out, err, status = krane_black_box("global-deploy", "#{KubeclientHelper::TEST_CONTEXT} #{flags}")
-      assert_empty(out)
-      refute_match(namespace_name, err) # Asserting that the namespace is not pruned
-      assert_match("Pruned 1 resource and successfully deployed 1 resource", err)
-      assert_predicate(status, :success?)
-    end
-  ensure
-    build_kubectl.run("delete", "-f", fixture_path("globals"), use_namespace: false, log_failure: false)
-    build_kubectl.run("delete", "namespace", namespace_name, use_namespace: false, log_failure: false)
-  end
-
-  # Note: These tests assume a default storage class with a dynamic provisioner and 'Immediate' bind
-  def test_pvc
-    pvname = add_unique_prefix_for_test("local")
-    pv_created = false
-    storage_class_name = nil
-
-    result = deploy_global_fixtures("pvc", subset: ["wait_for_first_consumer_storage_class.yml"]) do |fixtures|
-      sc = fixtures["wait_for_first_consumer_storage_class.yml"]["StorageClass"].first
-      storage_class_name = sc["metadata"]["name"] # will be made unique by the test helper
-    end
-    assert_deploy_success(result)
-
-    TestProvisioner.prepare_pv(pvname, storage_class_name: storage_class_name)
-    pv_created = true
-
-    result = deploy_fixtures("pvc", subset: %w(pod.yml pvc.yml)) do |fixtures|
-      pvc = fixtures["pvc.yml"]["PersistentVolumeClaim"].find { |p| p["metadata"]["name"] = "with-storage-class" }
-      pvc["spec"]["storageClassName"] = storage_class_name
-    end
-    assert_deploy_success(result)
-
-    assert_logs_match_all([
-      "Successfully deployed 3 resource",
-      "Successful resources",
-      %r{PersistentVolumeClaim/with-storage-class\s+Bound},
-      %r{PersistentVolumeClaim/without-storage-class\s+Bound},
-      %r{Pod/pvc\s+Succeeded},
-    ], in_order: true)
-
-  ensure
-    kubeclient.delete_persistent_volume(pvname) if pv_created
-  end
-
-  def test_pvc_no_bind
-    pvname = add_unique_prefix_for_test("local")
-    storage_class_name = nil
-    pv_created = false
-
-    result = deploy_global_fixtures("pvc", subset: ["wait_for_first_consumer_storage_class.yml"]) do |fixtures|
-      sc = fixtures["wait_for_first_consumer_storage_class.yml"]["StorageClass"].first
-      storage_class_name = sc["metadata"]["name"] # will be made unique by the test helper
-    end
-    assert_deploy_success(result)
-
-    TestProvisioner.prepare_pv(pvname, storage_class_name: storage_class_name)
-    pv_created = true
-
-    result = deploy_fixtures("pvc", subset: ["pvc.yml"]) do |fixtures|
-      pvc = fixtures["pvc.yml"]["PersistentVolumeClaim"].first
-      pvc["spec"]["storageClassName"] = storage_class_name
-    end
-    assert_deploy_success(result)
-
-    assert_logs_match_all([
-      "Successfully deployed 2 resource",
-      "Successful resources",
-      %r{PersistentVolumeClaim/with-storage-class\s+Pending},
-      %r{PersistentVolumeClaim/without-storage-class\s+Bound},
-    ], in_order: true)
-
-  ensure
-    kubeclient.delete_persistent_volume(pvname) if pv_created
-  end
-
-  def test_pvc_immediate_bind
-    pvname = add_unique_prefix_for_test("local")
-    storage_class_name = nil
-    pv_created = false
-
-    result = deploy_global_fixtures("pvc", subset: ["wait_for_first_consumer_storage_class.yml"]) do |fixtures|
-      sc = fixtures["wait_for_first_consumer_storage_class.yml"]["StorageClass"].first
-      storage_class_name = sc["metadata"]["name"] # will be made unique by the test helper
-      sc["volumeBindingMode"] = "Immediate"
-    end
-    assert_deploy_success(result)
-
-    TestProvisioner.prepare_pv(pvname, storage_class_name: storage_class_name)
-    pv_created = true
-
-    result = deploy_fixtures("pvc", subset: ["pvc.yml"]) do |fixtures|
-      pvc = fixtures["pvc.yml"]["PersistentVolumeClaim"].first
-      pvc["spec"]["storageClassName"] = storage_class_name
-    end
-    assert_deploy_success(result)
-
-    assert_logs_match_all([
-      "Successfully deployed 2 resource",
-      "Successful resources",
-      %r{PersistentVolumeClaim/with-storage-class\s+Bound},
-      %r{PersistentVolumeClaim/without-storage-class\s+Bound},
-    ], in_order: true)
-
-  ensure
-    kubeclient.delete_persistent_volume(pvname) if pv_created
-  end
-
-  def test_pvc_no_pv
-    storage_class_name = nil
-
-    result = deploy_global_fixtures("pvc",
-    subset: ["wait_for_first_consumer_storage_class.yml"]) do |fixtures|
-      sc = fixtures["wait_for_first_consumer_storage_class.yml"]["StorageClass"].first
-      storage_class_name = sc["metadata"]["name"] # will be made unique by the test helper
-    end
-    assert_deploy_success(result)
-
-    result = deploy_fixtures("pvc", subset: ["pvc.yml", "pod.yml"]) do |fixtures|
-      pvc = fixtures["pvc.yml"]["PersistentVolumeClaim"].first
-      pvc["spec"]["storageClassName"] = storage_class_name
-    end
-    assert_deploy_failure(result)
-
-    assert_logs_match_all([
-      "Failed to deploy 1 priority resource",
-      "Pod/pvc: TIMED OUT (timeout: 10s)",
-      %r{Pod could not be scheduled because 0/\d+ nodes are available:},
-      /\d+ node[(]s[)] didn't find available persistent volumes to bind./,
-    ], in_order: true)
   end
 end

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -492,7 +492,7 @@ class SerialDeployTest < Krane::IntegrationTest
     Tempfile.open([@namespace, ".yml"]) do |f|
       f.write(YAML.dump(crd))
       f.fsync
-      @global_fixtures_deployed << f.path
+      @deployed_global_fixture_paths << f.path
       out, err, st = build_kubectl.run("create", "-f", f.path, log_failure: true, use_namespace: false)
       assert(st.success?, "Failed to create invalid CRD: #{out}\n#{err}")
     end

--- a/test/integration/global_deploy_test.rb
+++ b/test/integration/global_deploy_test.rb
@@ -7,24 +7,24 @@ class GlobalDeployTest < Krane::IntegrationTest
 
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector test=",
+      "Using resource selector app=krane,test=",
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
+      "  - StorageClass/#{storage_class_name}",
       "Phase 2: Checking initial resource statuses",
-      %r{StorageClass\/testing-storage-class[\w-]+\s+Not Found},
+      %r{StorageClass\/#{storage_class_name}\s+Not Found},
       "Phase 3: Deploying all resources",
       "Deploying resources:",
-      %r{StorageClass\/testing-storage-class[\w-]+ \(timeout: 300s\)},
-      %r{PriorityClass/testing-priority-class[\w-]+ \(timeout: 300s\)},
+      %r{StorageClass\/#{storage_class_name} \(timeout: 300s\)},
+      %r{PriorityClass/#{priority_class_name} \(timeout: 300s\)},
       "Don't know how to monitor resources of type StorageClass.",
-      %r{Assuming StorageClass\/testing-storage-class[\w-]+ deployed successfully.},
-      %r{Successfully deployed in [\d.]+s: PriorityClass/testing-priority-class[\w-]+, StorageClass\/testing-storage-},
+      %r{Assuming StorageClass\/#{storage_class_name} deployed successfully.},
+      %r{Successfully deployed in [\d.]+s: PriorityClass/#{priority_class_name}, StorageClass\/#{storage_class_name}},
       "Result: SUCCESS",
       "Successfully deployed 2 resources",
       "Successful resources",
-      "StorageClass/testing-storage-class",
-      "PriorityClass/testing-priority-class",
+      "StorageClass/#{storage_class_name}",
+      "PriorityClass/#{priority_class_name}",
     ])
   end
 
@@ -33,17 +33,17 @@ class GlobalDeployTest < Krane::IntegrationTest
 
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector test=",
+      "Using resource selector app=krane,test=",
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
+      "  - StorageClass/#{storage_class_name}",
       "Phase 2: Checking initial resource statuses",
-      %r{StorageClass\/testing-storage-class[\w-]+\s+Not Found},
+      %r{StorageClass\/#{storage_class_name}\s+Not Found},
       "Phase 3: Deploying all resources",
       "Deploying resources:",
       "Result: TIMED OUT",
       "Timed out waiting for 2 resources to deploy",
-      %r{StorageClass\/testing-storage-class[\w-]+: GLOBAL WATCH TIMEOUT \(0 seconds\)},
+      %r{StorageClass\/#{storage_class_name}: GLOBAL WATCH TIMEOUT \(0 seconds\)},
       "If you expected it to take longer than 0 seconds for your deploy to roll out, increase --global-timeout.",
     ])
   end
@@ -53,18 +53,18 @@ class GlobalDeployTest < Krane::IntegrationTest
 
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector test=",
+      "Using resource selector app=krane,test=",
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
-      "  - PriorityClass/testing-priority-class",
+      "  - StorageClass/#{storage_class_name}",
+      "  - PriorityClass/#{priority_class_name}",
       "Phase 2: Checking initial resource statuses",
-      %r{StorageClass\/testing-storage-class[\w-]+\s+Not Found},
-      %r{PriorityClass/testing-priority-class[\w-]+\s+Not Found},
+      %r{StorageClass\/#{storage_class_name}\s+Not Found},
+      %r{PriorityClass/#{priority_class_name}\s+Not Found},
       "Phase 3: Deploying all resources",
       "Deploying resources:",
-      %r{StorageClass\/testing-storage-class[\w-]+ \(timeout: 300s\)},
-      %r{PriorityClass/testing-priority-class[\w-]+ \(timeout: 300s\)},
+      %r{StorageClass\/#{storage_class_name} \(timeout: 300s\)},
+      %r{PriorityClass/#{priority_class_name} \(timeout: 300s\)},
       "Result: SUCCESS",
       "Deployed 2 resources",
       "Deploy result verification is disabled for this deploy.",
@@ -74,7 +74,7 @@ class GlobalDeployTest < Krane::IntegrationTest
   end
 
   def test_global_deploy_task_empty_selector_validation_failure
-    assert_deploy_failure(deploy_global_fixtures('globals', selector: ""))
+    assert_deploy_failure(deploy_global_fixtures('globals', selector: false))
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
       "Result: FAILURE",
@@ -84,29 +84,29 @@ class GlobalDeployTest < Krane::IntegrationTest
   end
 
   def test_global_deploy_task_success_selector
-    selector = "app=krane2"
+    selector = "extraSelector=krane2"
     assert_deploy_success(deploy_global_fixtures('globals', selector: selector))
 
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector #{selector}",
+      "Using resource selector #{selector}", # there are more, but this one should be listed first
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
+      "  - StorageClass/#{storage_class_name}",
       "Phase 2: Checking initial resource statuses",
-      %r{StorageClass\/testing-storage-class[\w-]+\s+Not Found},
+      %r{StorageClass\/#{storage_class_name}\s+Not Found},
       "Phase 3: Deploying all resources",
       "Deploying resources:",
-      %r{PriorityClass/testing-priority-class[\w-]+ \(timeout: 300s\)},
-      %r{StorageClass\/testing-storage-class[\w-]+ \(timeout: 300s\)},
+      %r{PriorityClass/#{priority_class_name} \(timeout: 300s\)},
+      %r{StorageClass\/#{storage_class_name} \(timeout: 300s\)},
       "Don't know how to monitor resources of type StorageClass.",
-      %r{Assuming StorageClass\/testing-storage-class[\w-]+ deployed successfully.},
+      "Assuming StorageClass/#{storage_class_name} deployed successfully.",
       /Successfully deployed in [\d.]+s/,
       "Result: SUCCESS",
       "Successfully deployed 2 resources",
       "Successful resources",
-      "StorageClass/testing-storage-class",
-      "PriorityClass/testing-priority-class",
+      "StorageClass/#{storage_class_name}",
+      "PriorityClass/#{priority_class_name}",
     ])
   end
 
@@ -118,60 +118,74 @@ class GlobalDeployTest < Krane::IntegrationTest
 
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector test=",
+      "Using resource selector app=krane,test=",
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
+      "  - StorageClass/#{storage_class_name}",
       "Result: FAILURE",
       "Template validation failed",
     ])
   end
 
   def test_global_deploy_prune_success
-    assert_deploy_success(deploy_global_fixtures('globals', clean_up: false, selector: 'test=prune1'))
+    selector = 'extraSelector=prune1'
+    assert_deploy_success(deploy_global_fixtures('globals', clean_up: false, selector: selector))
     reset_logger
-    assert_deploy_success(deploy_global_fixtures('globals', subset: 'storage_classes.yml', selector: 'test=prune1'))
+    assert_deploy_success(deploy_global_fixtures('globals', subset: 'storage_classes.yml', selector: selector))
+
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector test=prune1",
+      "Using resource selector #{selector}",
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
+      "  - StorageClass/#{storage_class_name}",
       "Phase 2: Checking initial resource statuses",
-      %r{StorageClass\/testing-storage-class[\w-]+\s+Exists},
+      %r{StorageClass\/#{storage_class_name}\s+Exists},
       "Phase 3: Deploying all resources",
-      %r{Deploying StorageClass\/testing-storage-class[\w-]+ \(timeout: 300s\)},
-      "The following resources were pruned: priorityclass.scheduling.k8s.io/testing-priority-class",
-      %r{Successfully deployed in [\d.]+s: StorageClass\/testing-storage-class},
+      %r{Deploying StorageClass\/#{storage_class_name} \(timeout: 300s\)},
+      "The following resources were pruned: priorityclass.scheduling.k8s.io/#{priority_class_name}",
+      %r{Successfully deployed in [\d.]+s: StorageClass\/#{storage_class_name}},
       "Result: SUCCESS",
       "Pruned 1 resource and successfully deployed 1 resource",
       "Successful resources",
-      "StorageClass/testing-storage-class",
+      "StorageClass/#{storage_class_name}",
     ])
   end
 
   def test_no_prune_global_deploy_success
-    assert_deploy_success(deploy_global_fixtures('globals', clean_up: false, selector: 'test=prune2'))
+    selector = 'extraSelector=prune2'
+    assert_deploy_success(deploy_global_fixtures('globals', clean_up: false, selector: selector))
     reset_logger
     assert_deploy_success(deploy_global_fixtures('globals', subset: 'storage_classes.yml',
-      selector: "test=prune2", prune: false))
+      selector: selector, prune: false))
     assert_logs_match_all([
       "Phase 1: Initializing deploy",
-      "Using resource selector test=prune2",
+      "Using resource selector #{selector}",
       "All required parameters and files are present",
       "Discovering resources:",
-      "  - StorageClass/testing-storage-class",
+      "  - StorageClass/#{storage_class_name}",
       "Phase 2: Checking initial resource statuses",
-      %r{StorageClass\/testing-storage-class[\w-]+\s+Exists},
+      %r{StorageClass\/#{storage_class_name}\s+Exists},
       "Phase 3: Deploying all resources",
-      %r{Deploying StorageClass\/testing-storage-class[\w-]+ \(timeout: 300s\)},
-      %r{Successfully deployed in [\d.]+s: StorageClass\/testing-storage-class},
+      %r{Deploying StorageClass\/#{storage_class_name} \(timeout: 300s\)},
+      %r{Successfully deployed in [\d.]+s: StorageClass\/#{storage_class_name}},
       "Result: SUCCESS",
       "Successfully deployed 1 resource",
       "Successful resources",
-      "StorageClass/testing-storage-class",
+      "StorageClass/#{storage_class_name}",
     ])
     refute_logs_match(/[pP]runed/)
-    assert_deploy_success(deploy_global_fixtures('globals', selector: 'test=prune2'))
+    refute_logs_match(priority_class_name)
+    assert_deploy_success(deploy_global_fixtures('globals', selector: selector))
+  end
+
+  private
+
+  def storage_class_name
+    @storage_class_name ||= add_unique_prefix_for_test("testing-storage-class")
+  end
+
+  def priority_class_name
+    @priority_class_name ||= add_unique_prefix_for_test("testing-priority-class")
   end
 end

--- a/test/integration/global_deploy_test.rb
+++ b/test/integration/global_deploy_test.rb
@@ -129,7 +129,7 @@ class GlobalDeployTest < Krane::IntegrationTest
 
   def test_global_deploy_prune_success
     selector = 'extraSelector=prune1'
-    assert_deploy_success(deploy_global_fixtures('globals', clean_up: false, selector: selector))
+    assert_deploy_success(deploy_global_fixtures('globals', selector: selector))
     reset_logger
     assert_deploy_success(deploy_global_fixtures('globals', subset: 'storage_classes.yml', selector: selector))
 
@@ -154,7 +154,7 @@ class GlobalDeployTest < Krane::IntegrationTest
 
   def test_no_prune_global_deploy_success
     selector = 'extraSelector=prune2'
-    assert_deploy_success(deploy_global_fixtures('globals', clean_up: false, selector: selector))
+    assert_deploy_success(deploy_global_fixtures('globals', selector: selector))
     reset_logger
     assert_deploy_success(deploy_global_fixtures('globals', subset: 'storage_classes.yml',
       selector: selector, prune: false))

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -17,11 +17,11 @@ module Krane
     def run
       super do
         @namespace = TestProvisioner.claim_namespace(name)
-        @global_fixtures_deployed = []
+        @deployed_global_fixture_paths = []
       end
     ensure
       TestProvisioner.delete_namespace(@namespace)
-      delete_globals(@global_fixtures_deployed)
+      delete_globals(@deployed_global_fixture_paths)
     end
 
     def delete_globals(dirs)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -33,9 +33,11 @@ include(StatsD::Instrument::Assertions)
 
 Dir.glob(File.expand_path("../helpers/*.rb", __FILE__)).each { |file| require file }
 
-Mocha::Configuration.prevent(:stubbing_method_unnecessarily)
-Mocha::Configuration.prevent(:stubbing_non_existent_method)
-Mocha::Configuration.prevent(:stubbing_non_public_method)
+Mocha.configure do |c|
+  c.stubbing_method_unnecessarily = :prevent
+  c.stubbing_non_existent_method = :prevent
+  c.stubbing_non_public_method = :prevent
+end
 
 if ENV["PARALLELIZE_ME"]
   Minitest::Reporters.use!([


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Make it safer and easier to write tests that modify the global namespace.

Related to https://github.com/Shopify/krane/issues/637.

**How is this accomplished?**

- [x] Make `deploy_global_fixtures` automatically rescope all resources correctly, including CRDs.
- [x] Make the test suite automatically clean up everything deployed by `deploy_global_fixtures` _after_ the test is finished (the same time we clean up namespaces).
- [x] Get rid of all usage of `deploy_global_fixtures_non_namespaced` and the `clean_up: false` option on `global_deploy_dirs_without_profiling`
- [x] Scope all CRD name fields to the test to make them truly unique. Adjust a boatload of tests.
- [x] Move any tests that are now concurrency-safe out of the serial test file and make sure the reasons the others can't move are well documented.

Note that unfortunately any test that creates CRDs still isn't concurrency-safe, because it effectively changes our dynamic pruning whitelist. If a CRD is removed in the middle of a namespaced deploy, that deploy will fail with an `apply` error because the pruning whitelist will reference a non-existent kind. That said, CRD tests are still improved by this PR in that the suite now cleans up after them properly with no additional effort on the test writer's part, and we no longer need to wait for the CRDs to fully go away between tests because they are actually unique (and won't interfere with each other).

**What could go wrong?**
Tests could be invalidated or become flakey.
