### PR TITLE
Relax thor dependency requirement

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("oj", "~> 3.0")
   spec.add_dependency("concurrent-ruby", "~> 1.1")
   spec.add_dependency("jsonpath", "~> 0.9.6")
-  spec.add_dependency("thor", "~>  0.20.3")
+  spec.add_dependency("thor", ">= 0.20.3", "< 2.0")
 
   # Basics
   spec.add_development_dependency("bundler")


### PR DESCRIPTION
Relax thor dependency requirement:

- ### Problem

  Rails made thor 1.0 a dependency requirement. Application
  using Rails HEAD and krane can't have their dependencies resolved
  since there is a version conflict.