### PR TITLE
fix the --filename option`

### DIFF
--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -153,7 +153,7 @@ Old flag | New flag | Comments
 Old flag | New flag | Comments
 --- | --- | ---
 --bindings=BINDINGS | --bindings=BINDINGS |
---template-dir | -f, --filename | Changed to be more aligned with `kubectl apply` and other krane tasks
+--template-dir | -f, --filenames | Changed to be more aligned with `kubectl apply` and other krane tasks
 $REVISION | --current-sha | The environment variable REVISION was dropped in favour of an explicit flag
 [none] | --stdin | Allow template filenames given from stdin stream
 


### PR DESCRIPTION
```$ krane help render
Usage:
  krane render

Options:
      [--bindings=foo=bar abc=def]                                               # Bindings for erb
  f, [--filenames=config/deploy/production config/deploy/my-extra-resource.yml]  # Directories and files to render
      [--stdin], [--no-stdin]                                                    # Read resources from stdin
      [--current-sha=SHA]                                                        # Expose SHA `current_sha` in ERB bindings

Render templates
```

the `--filename` option needs to be `--filenames` to be consistent with the code/usage description.

**What are you trying to accomplish with this PR?**
...

**How is this accomplished?**
...

**What could go wrong?**
...
