### PR TITLE
Prints the correct argument name in error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Bug Fixes*
+- Prints the correct argument name in error message. [#670](https://github.com/Shopify/krane/pull/670)
+
 ## 1.1.0
 
 *Bug Fixes*

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -256,7 +256,7 @@ module Krane
       if cause == :gave_up
         debug_heading = ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow
         helpful_info << "If you expected it to take longer than #{info_hash[:timeout]} seconds for your deploy"\
-        " to roll out, increase --max-watch-seconds."
+        " to roll out, increase --global-timeout."
       elsif deploy_failed?
         debug_heading = ColorizedString.new("#{id}: FAILED").red
         helpful_info << failure_message if failure_message.present?

--- a/test/integration/global_deploy_test.rb
+++ b/test/integration/global_deploy_test.rb
@@ -44,7 +44,7 @@ class GlobalDeployTest < Krane::IntegrationTest
       "Result: TIMED OUT",
       "Timed out waiting for 2 resources to deploy",
       %r{StorageClass\/testing-storage-class[\w-]+: GLOBAL WATCH TIMEOUT \(0 seconds\)},
-      "If you expected it to take longer than 0 seconds for your deploy to roll out, increase --max-watch-seconds.",
+      "If you expected it to take longer than 0 seconds for your deploy to roll out, increase --global-timeout.",
     ])
   end
 

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -1335,7 +1335,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
       "Successful resources",
       "Service/multi-replica",
       "Deployment/undying: GLOBAL WATCH TIMEOUT (5 seconds)",
-      "If you expected it to take longer than 5 seconds for your deploy to roll out, increase --max-watch-seconds.",
+      "If you expected it to take longer than 5 seconds for your deploy to roll out, increase --global-timeout.",
     ], in_order: true)
   end
 


### PR DESCRIPTION
This had me confused for a while.