### PR TITLE
Relax googleauth version

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4.0'
   spec.add_dependency("activesupport", ">= 5.0")
   spec.add_dependency("kubeclient", "~> 4.3")
-  spec.add_dependency("googleauth", "~> 0.8")
+  spec.add_dependency("googleauth", [">= 0.8.0", "< 1"])
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
   spec.add_dependency("statsd-instrument", ['>= 2.8', "< 3.1"])


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Makes it easier to install in apps that have other versions of googleauth

**How is this accomplished?**
Relax googleauth version to be greater than or equal to the version it used to require

**What could go wrong?**
Deployments fail if there's a new version of googleauth with a breaking change (any version of 0.x does not have any compatibility promises according to semver)
