### PR TITLE
fix: update matching for Kubernetes error message when server-dry-run is not supported

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -16,7 +16,7 @@ module Krane
     TIMEOUT = 5.minutes
     LOG_LINE_COUNT = 250
     SERVER_DRY_RUN_DISABLED_ERROR =
-    /(unknown flag: --server-dry-run)|(does[\s\']n[o|']t support dry[-\s]run)|(dryRun alpha feature is disabled)/
+      /(unknown flag: --server-dry-run)|(does[\s\']n[o|']t support dry[-\s]run)|(dryRun alpha feature is disabled)/
 
     DISABLE_FETCHING_LOG_INFO = 'DISABLE_FETCHING_LOG_INFO'
     DISABLE_FETCHING_EVENT_INFO = 'DISABLE_FETCHING_EVENT_INFO'

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -16,7 +16,7 @@ module Krane
     TIMEOUT = 5.minutes
     LOG_LINE_COUNT = 250
     SERVER_DRY_RUN_DISABLED_ERROR =
-      /(unknown flag: --server-dry-run)|(doesn't support dry-run)|(dryRun alpha feature is disabled)/
+      /(unknown flag: --server-dry-run)|(doesn't support dry-run)|(does not support dry run)|(dryRun alpha feature is disabled)/
 
     DISABLE_FETCHING_LOG_INFO = 'DISABLE_FETCHING_LOG_INFO'
     DISABLE_FETCHING_EVENT_INFO = 'DISABLE_FETCHING_EVENT_INFO'

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -16,7 +16,7 @@ module Krane
     TIMEOUT = 5.minutes
     LOG_LINE_COUNT = 250
     SERVER_DRY_RUN_DISABLED_ERROR =
-      /(unknown flag: --server-dry-run)|(doesn't support dry-run)|(does not support dry run)|(dryRun alpha feature is disabled)/
+    /(unknown flag: --server-dry-run)|(does[\s\']n[o|']t support dry[-\s]run)|(dryRun alpha feature is disabled)/
 
     DISABLE_FETCHING_LOG_INFO = 'DISABLE_FETCHING_LOG_INFO'
     DISABLE_FETCHING_EVENT_INFO = 'DISABLE_FETCHING_EVENT_INFO'

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -258,10 +258,10 @@ class KubernetesResourceTest < Krane::TestCase
     kubectl.expects(:run)
       .with('apply', '-f', anything, '--server-dry-run', '--output=name', anything)
       .returns([
-      "Some Raw Output",
-      "Error from kubectl: admission webhook some-webhook does not support dry run",
-      stub(success?: false),
-    ])
+        "Some Raw Output",
+        "Error from kubectl: admission webhook some-webhook does not support dry run",
+        stub(success?: false),
+      ])
     resource.validate_definition(kubectl)
     refute(resource.validation_failed?, "Failed to ignore server dry run responses matching:
       #{Krane::KubernetesResource::SERVER_DRY_RUN_DISABLED_ERROR}")

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -259,7 +259,7 @@ class KubernetesResourceTest < Krane::TestCase
       .with('apply', '-f', anything, '--server-dry-run', '--output=name', anything)
       .returns([
       "Some Raw Output",
-      "Error from kubectl: something does not support dry run",
+      "Error from kubectl: admission webhook some-webhook does not support dry run",
       stub(success?: false),
     ])
     resource.validate_definition(kubectl)

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -249,7 +249,7 @@ class KubernetesResourceTest < Krane::TestCase
     refute_includes(resource.validation_error_msg, 'S3CR3T')
   end
 
-    def test_validate_definition_ignores_server_dry_run_unsupported_by_webhook_response
+  def test_validate_definition_ignores_server_dry_run_unsupported_by_webhook_response
     resource = DummySensitiveResource.new
     kubectl.expects(:run)
       .with('apply', '-f', anything, '--dry-run', '--output=name', anything)
@@ -263,7 +263,7 @@ class KubernetesResourceTest < Krane::TestCase
       stub(success?: false),
     ])
     resource.validate_definition(kubectl)
-    refute(resource.validation_failed?, "Failed to ignore server dry run responses matching: 
+    refute(resource.validation_failed?, "Failed to ignore server dry run responses matching:
       #{Krane::KubernetesResource::SERVER_DRY_RUN_DISABLED_ERROR}")
   end
 

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -249,7 +249,7 @@ class KubernetesResourceTest < Krane::TestCase
     refute_includes(resource.validation_error_msg, 'S3CR3T')
   end
 
-  def test_validate_definition_ignores_server_dry_run_disabled_response
+    def test_validate_definition_ignores_server_dry_run_unsupported_by_webhook_response
     resource = DummySensitiveResource.new
     kubectl.expects(:run)
       .with('apply', '-f', anything, '--dry-run', '--output=name', anything)


### PR DESCRIPTION

**What are you trying to accomplish with this PR?**
Current error message contains 1does not support dry run" not "doesn't support dry-run"
It is not clear if the message previously was "doesn't support dry-run" so I left that in the matching expression.

https://github.com/kubernetes/apiserver/blob/7dc4ceb2fd3311166a78bdf6a4eec4c194364dd0/pkg/admission/plugin/webhook/errors/statuserror.go#L61

...

**How is this accomplished?**
updated existing regex `Krane::KubernetesResource::SERVER_DRY_RUN_DISABLED_ERROR`
...

**What could go wrong?**
...
