### PR TITLE
Remove usage of deprecated_(timestamp,count) fields

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -432,7 +432,6 @@ module Krane
       def self.extract_event_count(pieces)
         series = pieces[FIELDS.index(".series")]
         count = pieces[FIELDS.index(".count")]
-        deprecated_count = pieces[FIELDS.index(".deprecatedCount")]
 
         # Find the right event count according to Kubernetes API and kubectl version
         if count.present? && count != FIELD_EMPTY_VALUE
@@ -441,18 +440,12 @@ module Krane
           # kubectl 1.16 uses Events/v1, which has the .series/.count field
           count_regex = /count:(?<value>\S+?(?=\s))/
           count_regex.match(series)['value']
-        elsif deprecated_count.present? && deprecated_count != FIELD_EMPTY_VALUE
-          # kubectl < 1.16 uses events.k8s.io/v1beta1, which has .deprecatedCount
-          deprecated_count
-        else
-          "1" # Fallback to 1 when all count fields are null
         end
       end
 
       def self.extract_event_timestamp(pieces)
         series = pieces[FIELDS.index(".series")]
         last_timestamp = pieces[FIELDS.index(".lastTimestamp")]
-        deprecated_timestamp = pieces[FIELDS.index(".deprecatedLastTimestamp")]
 
         # Find the right event timestamp according to Kubernetes API and kubectl version
         if last_timestamp.present? && last_timestamp != FIELD_EMPTY_VALUE
@@ -461,11 +454,6 @@ module Krane
           # kubectl 1.16 uses Events/v1, which has the .series/.lastObservedTime field
           timestamp_regex = /lastObservedTime:(?<value>\S+?(?=\]))/
           timestamp_regex.match(series)['value']
-        elsif deprecated_timestamp.present? && deprecated_timestamp != FIELD_EMPTY_VALUE
-          # kubectl < 1.16 uses events.k8s.io/v1beta1, which has .deprecatedLastTimestamp
-          deprecated_timestamp
-        else
-          pieces[FIELDS.index(".eventTime")] # Fallback to eventTime when other timestamp fields are null
         end
       end
       private_class_method :extract_event_timestamp, :extract_event_count


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Do not use `deprecated` fields of k8s Events api.

**How is this accomplished?**

This PR just removes code that was added to handle a situation where `count` and `lastTimestamp` k8s fields where not available locally when running tests.

After investigation with Danny, seems the problem happens when you have a `minikube` cluster  with incompatible `client` and `server`, which was my case:

```bash
» kubectl --context minikube version                                                                               
Client Version: version.Info{Major:"1", Minor:"13+", GitVersion:"v1.13.11-dispatcher", GitCommit:"2e298c7e992f83f47af60cf4830b11c7370f6668", GitTreeState:"clean", BuildDate:"2019-09-19T22:26:40Z", GoVersion:"go1.11.13", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"16", GitVersion:"v1.16.2", GitCommit:"c97fe5036ef3df2967d086711e6c0c405941e14b", GitTreeState:"clean", BuildDate:"2019-10-15T19:09:08Z", GoVersion:"go1.12.10", Compiler:"gc", Platform:"linux/amd64"}
``` 

**Update:** Actually, the real cause is that `Kubernetes 1.16.2` is affected by a bug as described [here](https://github.com/Shopify/krane/pull/666#issuecomment-575798448).

Which caused this:

<img width="1228" alt="Screen Shot 2020-01-16 at 4 22 13 PM" src="https://user-images.githubusercontent.com/411301/72563793-6a600800-387c-11ea-9185-9f4facdfeeb8.png">


To fix it, I deleted my local cluster with `minikube delete` and recreated one with `dev up`, which gave me this:

```bash
» kubectl --context minikube version                                                                               
Client Version: version.Info{Major:"1", Minor:"13+", GitVersion:"v1.13.11-dispatcher", GitCommit:"2e298c7e992f83f47af60cf4830b11c7370f6668", GitTreeState:"clean", BuildDate:"2019-09-19T22:26:40Z", GoVersion:"go1.11.13", Compiler:"gc", Platform:"darwin/amd64"}
Server Version: version.Info{Major:"1", Minor:"11", GitVersion:"v1.11.10", GitCommit:"7a578febe155a7366767abce40d8a16795a96371", GitTreeState:"clean", BuildDate:"2019-05-01T04:05:01Z", GoVersion:"go1.10.8", Compiler:"gc", Platform:"linux/amd64"}
```

Which made the test pass 👍 

<img width="1227" alt="Screen Shot 2020-01-16 at 4 25 43 PM" src="https://user-images.githubusercontent.com/411301/72564030-e22e3280-387c-11ea-8bab-3cdc84850545.png">

**What could go wrong?**

I can't think of any problem as our tests are running in `buildkite` and locally, but it should be easier to revert if we bump into a new problem.
