### PR TITLE
`--template` is required to use `krane run`

### DIFF
--- a/README.md
+++ b/README.md
@@ -503,7 +503,7 @@ Based on this specification `krane run` will create a new pod with the entrypoin
 
 *Options:*
 
-* `--template=TEMPLATE`:  Specifies the name of the PodTemplate to use (default is `task-runner-template` if this option is not set).
+* `--template=TEMPLATE`: Specifies the name of the PodTemplate to use.
 * `--env-vars=ENV_VARS`: Accepts a list of environment variables to be added to the pod template. For example, `--env-vars="ENV=VAL ENV2=VAL2"` will make `ENV` and `ENV2` available to the container.
 * `--command=`: Override the default command in the container image.
 * `--no-verify-result`: Skip verification of pod success


### PR DESCRIPTION
When reading the usage of `krane run` in the `README.md`, I noticed the `--template` option was documented as being optional.

This doesn't match the current behaviour of `krane run`:

```
$ krane run
No value provided for required options '--template'
```

After chatting with @dturn, it sounds like this was a typo in the `README.md`, hence this PR. 😄 