### PR TITLE
Use metadata.generation instead of deprecated attributes

### DIFF
--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -80,8 +80,7 @@ module Krane
     def parent_of_pod?(pod_data)
       return false unless pod_data.dig("metadata", "ownerReferences")
 
-      template_generation = @instance_data.dig("spec", "templateGeneration") ||
-        @instance_data.dig("metadata", "annotations", "deprecated.daemonset.template.generation")
+      template_generation = @instance_data.dig("metadata", "generation")
       return false unless template_generation.present?
 
       pod_data["metadata"]["ownerReferences"].any? { |ref| ref["uid"] == @instance_data["metadata"]["uid"] } &&


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Avoid usage of `spec.templateGeneration` as it was deprecated in `k8s 1.7` and `deprecated.daemonset.template.generation` in favor or the standard api `metadata.generation`.

For context: https://github.com/kubernetes/kubernetes/issues/49336 and https://github.com/kubernetes/kubernetes/pull/49454.

Fixes #627.

**How is this accomplished?**

Changing:

```ruby
(...)
template_generation = @instance_data.dig("spec", "templateGeneration") ||
        @instance_data.dig("metadata", "annotations", "deprecated.daemonset.template.generation")
(...)
```

To:

```ruby
template_generation = @instance_data.dig("metadata", "generation")
```

**What could go wrong?**

The only scenario that I could think of is people trying to use `k8s 1.7` with a new release of `krane` after this commit gets merged *but* it would break in so many other scenarios that I don't think it is something that we have to consider, as our users can use an older version of the gem if they want to use an old `k8s` version.

Reviewers more experienced with `k8s`: Can you see other problems that I couldn't see?
