### PR TITLE
Deploy CustomResources after dependencies

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -60,14 +60,14 @@ module Krane
       before_crs = %w(
         ResourceQuota
         NetworkPolicy
-      )
-      after_crs = %w(
         ConfigMap
         PersistentVolumeClaim
         ServiceAccount
         Role
         RoleBinding
         Secret
+      )
+      after_crs = %w(
         Pod
       )
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

CustomResources are quite likely to depend on things like Secrets, RBAC resources or even PVCs. They should be available before blocking on monitoring the CustomResources for success.

Fixes #670

**How is this accomplished?**

This change ensures that CustomResources are pre-deployed after the other pre-deployed resource types.

**What could go wrong?**

WW3?