### PR TITLE
[bugfix] Restore default value for verbose-log-prefix

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -26,7 +26,7 @@ module Krane
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
-                                  default: true },
+                                  default: false },
         "verify-result" => { type: :boolean, default: true,
                              desc: "Verify workloads correctly deployed" },
       }


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix the default value of --verbose-log-prefix on the deploy command. This was accidentally flipped with the move to Thor.

**How is this accomplished?**
Flipping the default.

**What could go wrong?**
If someone liked that it was flipped, they might be upset?
