### PR TITLE
Don't run delete with no files

### DIFF
--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -25,6 +25,7 @@ module Krane
     end
 
     def delete_globals(dirs)
+      return if dirs.empty?
       kubectl = build_kubectl
       paths = dirs.flat_map { |d| ["-f", d] }
       kubectl.run("delete", "--wait=false", *paths, log_failure: true, use_namespace: false)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix a warning in the test logs:

```
The following command failed (attempt 1/1): kubectl delete --wait\=false --context\=minikube --request-timeout\=5s
[WARN][2020-01-23 00:20:11 +0000]	error: You must provide one or more resources by argument or filename.
Example resource specifications include:
   '-f rsrc.yaml'
   '--filename=rsrc.json'
   '<resource> <name>'
   '<resource>'
 
```

**How is this accomplished?**
Not trying to delete nothing.

**What could go wrong?**
Not much.
