### PR TITLE
Fix some warnings on Ruby 2.7.0

### DIFF
--- a/lib/krane/kubernetes_resource/custom_resource.rb
+++ b/lib/krane/kubernetes_resource/custom_resource.rb
@@ -62,7 +62,7 @@ module Krane
       kind
     end
 
-    def validate_definition(*)
+    def validate_definition(*, **)
       super
 
       @crd.validate_rollout_conditions

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -66,7 +66,7 @@ module Krane
       @rollout_conditions = nil
     end
 
-    def validate_definition(*)
+    def validate_definition(*, **)
       super
 
       validate_rollout_conditions

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -97,7 +97,7 @@ module Krane
       progress_condition.present? ? deploy_failing_to_progress? : super
     end
 
-    def validate_definition(*)
+    def validate_definition(*, **)
       super
 
       unless REQUIRED_ROLLOUT_TYPES.include?(required_rollout) || percent?(required_rollout)

--- a/lib/krane/statsd.rb
+++ b/lib/krane/statsd.rb
@@ -35,10 +35,10 @@ module Krane
         end
 
         metric ||= "#{method_name}.duration"
-        self::InstrumentationProxy.send(:define_method, method_name) do |*args, &block|
+        self::InstrumentationProxy.send(:define_method, method_name) do |*args, **kwargs, &block|
           begin
             start_time = Time.now.utc
-            super(*args, &block)
+            super(*args, **kwargs, &block)
           rescue
             error = true
             raise

--- a/test/helpers/mock_resource.rb
+++ b/test/helpers/mock_resource.rb
@@ -4,7 +4,7 @@ MockResource = Struct.new(:id, :hits_to_complete, :status) do
   self::SYNC_DEPENDENCIES = []
   self::SENSITIVE_TEMPLATE_CONTENT = false
 
-  def debug_message(*)
+  def debug_message(*, **)
     @debug_message
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -201,7 +201,7 @@ module Krane
     def build_runless_kubectl
       obj = Krane::Kubectl.new(task_config: task_config(namespace: 'test'),
         log_failure_by_default: false)
-      def obj.run(*)
+      def obj.run(*,**)
         ["", "", SystemExit.new(0)]
       end
 


### PR DESCRIPTION

**What are you trying to accomplish with this PR?**

Fix a few warnings coming out during deploys using ruby 2.7.0 like so:

```
[INFO][2020-01-24 11:17:20 -0500]	------------------------------------Phase 1: Initializing deploy------------------------------------
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/statsd.rb:41: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/deploy_task.rb:254: warning: The called method `validate_configuration' is defined here
[INFO][2020-01-24 11:17:25 -0500]	All required parameters and files are present
[INFO][2020-01-24 11:17:25 -0500]	Discovering resources:
[INFO][2020-01-24 11:17:28 -0500]	  - Ingress/tunnel-server-ingress
[INFO][2020-01-24 11:17:28 -0500]	  - Service/tunnel-server
[INFO][2020-01-24 11:17:28 -0500]	  - Deployment/tunnel-server
[INFO][2020-01-24 11:17:28 -0500]	  - Certificate/localtunnel.gadget.dev-production
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/kubernetes_resource/custom_resource.rb:66: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/kubernetes_resource.rb:135: warning: The called method `validate_definition' is defined here
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/kubernetes_resource/deployment.rb:101: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/kubernetes_resource.rb:135: warning: The called method `validate_definition' is defined here
<snip>
[INFO][2020-01-24 11:17:40 -0500]	----------------------------------Phase 4: Deploying all resources----------------------------------
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/statsd.rb:41: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/Users/airhorns/.rbenv/versions/2.7.0/lib/ruby/gems/2.7.0/gems/krane-1.1.1/lib/krane/resource_deployer.rb:70: warning: The called method `deploy_all_resources' is defined here
```

due to implicit passing of keyword arguments as the last argument


**How is this accomplished?**

Be explicit about keyword arguments where splats are used. It might be wise to start testing `krane` on a matrix of ruby versions though, but because the build process is private I'm not really sure how to help with that. 

**What could go wrong?**

Not much if the tests are green methinks! 