### PR TITLE
More sensible number of debug logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 ## next
 
+*Enhancements*
+
 *Bug Fixes*
 - Help ruby correctly identify kubectl output encoding. [#646](https://github.com/Shopify/krane/pull/646)
+
+*Other*
+- Reduces the number of container logs printed for failures from 250 to 25 to reduce noise. [#676](https://github.com/Shopify/krane/pull/676)
 
 ## 1.1.1
 

--- a/lib/krane/container_logs.rb
+++ b/lib/krane/container_logs.rb
@@ -3,7 +3,7 @@ module Krane
   class ContainerLogs
     attr_reader :lines, :container_name
 
-    DEFAULT_LINE_LIMIT = 250
+    DEFAULT_LINE_LIMIT = 25
 
     def initialize(parent_id:, container_name:, namespace:, context:, logger:)
       @parent_id = parent_id


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix a pet peeve I have as a user of Krane rather than as a maintainer: when we print failure logs, we select WAY too many lines. So many that it's difficult to find/interpret the rest of the deploy summary. I propose that we slash the number by a factor of 10.

**How is this accomplished?**
Changing a constant.

**What could go wrong?**
People who don't have robust logging systems might not like it.

@Shopify/production-excellence wdyt?