### PR TITLE
Time out when timeout exactly reached

### DIFF
--- a/lib/krane/resource_watcher.rb
+++ b/lib/krane/resource_watcher.rb
@@ -68,7 +68,7 @@ module Krane
     end
 
     def global_timeout?(started_at)
-      @timeout && (Time.now.utc - started_at > @timeout)
+      @timeout && (Time.now.utc - started_at >= @timeout)
     end
 
     def sleep_until_next_sync(min_interval)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix this flakey test: https://buildkite.com/shopify/krane/builds/114#90639261-441d-4758-8c5c-241fafdfe825/833-1014

**How is this accomplished?**
The test is racey because it effectively relies on `t1 - t2 > 0`, where t1 and t2 are set very, very close together in the code. In the following experiment with the times as close as they can be, t2 is greater than t1 about 52% of the time.

```
results = []; 100000.times { one = Time.now.utc; two = Time.now.utc; results << (two > one)}; results.count { |r| r }
```

An easy fix is to look at `t1 - t2 >= timeout` instead. I think this is also more logical: if t1 is 17:00:00.000000, timeout is 5s and t2 is miraculously 17:00:05.000000, I think intuitively we should time out. 

**What could go wrong?**
This shouldn't mater in production, because people are not sensitive to subsecond timeout accuracy in any case. We could even `.to_i` our timestamps as far as production is concerned, though that would make a bunch of tests that run instantly take at least a second each.


@Shopify/production-excellence 