### PR TITLE
Document passing multiple files to --bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,9 @@ $ krane render --bindings='@config/production.json'
 
 # Load YAML file from ./config (.yaml or yml supported)
 $ krane render --bindings='@config/production.yaml'
+
+# Load multiple files via a space separated string
+$ krane render --bindings='@config/production.yaml' '@config/common.yaml'
 ```
 
 #### Using partials


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Alleviate confusion on how to use multiple bindings files.  This was confusing when migrating from kubernetes-deploy that used multiple entries like `--bindings=@file1.yml --bindings=@file2.yml`

**How is this accomplished?**
Document an example of using multiple bindings files.

**What could go wrong?**
Nothing.  Its markdown!
