### PR TITLE
Drop Ruby 2.4, Add Ruby 2.6, Add k8s 1.17

### DIFF
--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -9,7 +9,7 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
-  - label: 'Run Test Suite (:kubernetes: 1.17-latest :ruby: 2.7)'
+  - label: 'Run Test Suite (:kubernetes: 1.17-latest :ruby: 2.6)'
     command: bin/ci
     agents:
       queue: k8s-ci
@@ -17,13 +17,6 @@ steps:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.17-latest
       RUBY_VERSION: "2.7"
-  - label: 'Run Test Suite (:kubernetes: 1.17-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.17-latest
   - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
     command: bin/ci
     agents:

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -9,6 +9,14 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
+  - label: 'Run Test Suite (:kubernetes: 1.17-latest :ruby: 2.7)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.17-latest
+      RUBY_VERSION: "2.7"
   - label: 'Run Test Suite (:kubernetes: 1.17-latest)'
     command: bin/ci
     agents:

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -9,6 +9,13 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
+  - label: 'Run Test Suite (:kubernetes: 1.17-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.17-latest
   - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
     command: bin/ci
     agents:
@@ -51,4 +58,3 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.11-latest
-

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -1,6 +1,6 @@
 containers:
   default:
-    docker: circleci/ruby:2.4.6-node-browsers
+    docker: circleci/ruby:2.5.7-node-browsers
 
 steps:
   - label: Lint
@@ -16,7 +16,7 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.17-latest
-      RUBY_VERSION: "2.7"
+      RUBY_VERSION: "2.6"
   - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
     command: bin/ci
     agents:

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -1,6 +1,6 @@
 containers:
   default:
-    docker: circleci/ruby:2.5.7-node-browsers
+    docker: circleci/ruby:2.5.7
 
 steps:
   - label: Lint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - `--stdin` flag is deprecated. To read from STDIN, use `-f -` (can be combined with other files/directories) [#684](https://github.com/Shopify/krane/pull/684).
 - Reduces the number of container logs printed for failures from 250 to 25 to reduce noise. [#676](https://github.com/Shopify/krane/pull/676)
 - Remove hardcoded cloudsql class. [#680](https://github.com/Shopify/krane/pull/680)
+- Dropped support for Ruby 2.4 since it will be EoL shortly [#693](https://github.com/Shopify/krane/pull/693).
 
 ## 1.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## next
 
-...
+*Other*
+- Dropped support for Ruby 2.4 since it will be EoL shortly [#693](https://github.com/Shopify/krane/pull/693).
 
 ## 1.1.2
 *Enhancements*
@@ -14,7 +15,6 @@
 - `--stdin` flag is deprecated. To read from STDIN, use `-f -` (can be combined with other files/directories) [#684](https://github.com/Shopify/krane/pull/684).
 - Reduces the number of container logs printed for failures from 250 to 25 to reduce noise. [#676](https://github.com/Shopify/krane/pull/676)
 - Remove hardcoded cloudsql class. [#680](https://github.com/Shopify/krane/pull/680)
-- Dropped support for Ruby 2.4 since it will be EoL shortly [#693](https://github.com/Shopify/krane/pull/693).
 
 ## 1.1.1
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you need the ability to render dynamic values in templates before deploying, 
 
 ## Prerequisites
 
-* Ruby 2.4+
+* Ruby 2.5+
 * Your cluster must be running Kubernetes v1.11.0 or higher<sup>1</sup>
 
 <sup>1</sup> We run integration tests against these Kubernetes versions. You can find our

--- a/bin/ci
+++ b/bin/ci
@@ -17,5 +17,5 @@ docker run --rm \
     -e VERBOSE=1 \
     -e PARALLELISM=$PARALLELISM \
     -w /usr/src/app \
-    ruby:2.4 \
+    ruby:"${RUBY_VERSION:-2.5}" \
     bin/test

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = %w(lib)
 
-  spec.required_ruby_version = '>= 2.4.0'
+  spec.required_ruby_version = '>= 2.5.0'
   spec.add_dependency("activesupport", ">= 5.0")
   spec.add_dependency("kubeclient", "~> 4.3")
   spec.add_dependency("googleauth", "~> 0.8")


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Add tests for K8s 1.17
Add tests for Ruby 2.6
Ruby 2.4 is EOL 3/31 might as well drop it 6 weeks early as long as I'm in this code. 

**How is this accomplished?**
Update our pipeline file

**What could go wrong?**
Upset people who were still using 2.4. Though it's possible we don't cut a release before the 3/31 EoL date.

Sadly ruby 2.7 fails due to kuebclient https://github.com/abonas/kubeclient/issues/432