### PR TITLE
Don't consider `ContainerCannotRun` with a 128 exit code as doomed

### DIFF
--- a/test/unit/krane/kubernetes_resource/pod_test.rb
+++ b/test/unit/krane/kubernetes_resource/pod_test.rb
@@ -136,6 +136,23 @@ class PodTest < Krane::TestCase
     assert_equal(expected_msg.strip, pod.failure_message)
   end
 
+  def test_deploy_failed_is_false_for_container_cannot_run_error_with_128_exit_code
+    container_state = {
+      "state" => {
+        "terminated" => {
+          "message" => "Error: failed to start container 'foo': Error response from daemon: grpc: the client" \
+                       "connection is closing",
+          "reason" => "ContainerCannotRun",
+          "exitCode" => 128,
+        },
+      },
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+
+    refute_predicate(pod, :deploy_failed?)
+    assert_nil(pod.failure_message)
+  end
+
   def test_deploy_failed_is_true_for_evicted_unmanaged_pods
     template = pod_spec.merge(
       "status" => {

--- a/test/unit/krane/kubernetes_resource/pod_test.rb
+++ b/test/unit/krane/kubernetes_resource/pod_test.rb
@@ -153,6 +153,29 @@ class PodTest < Krane::TestCase
     assert_nil(pod.failure_message)
   end
 
+  def test_deploy_failed_is_true_for_container_cannot_run_with_crash_loop_backoff
+    container_state = {
+      "state" => {
+        "waiting" => {
+          "message" => "Back-off 2m40s restarting failed container=myapp-container pod=myapp-pod_default",
+          "reason" => "CrashLoopBackOff",
+        },
+      },
+      "lastState" => {
+        "terminated" => {
+          "message" => "Error: failed to start container 'foo': Error response from daemon: grpc: the client" \
+                       "connection is closing",
+          "reason" => "ContainerCannotRun",
+          "exitCode" => 128,
+        },
+      },
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+
+    assert_predicate(pod, :deploy_failed?)
+    assert_includes(pod.failure_message, 'Crashing repeatedly')
+  end
+
   def test_deploy_failed_is_true_for_evicted_unmanaged_pods
     template = pod_spec.merge(
       "status" => {


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Krane is treating a particular class of `ContainerCannotRun` termination reason as an unrecoverable failure - and so failing quickly - when it is in fact transient. This PR attempts to identify that case and not consider the pod rollout doomed.

**How is this accomplished?**

By ignoring `ContainerCannotRun` termination reasons only if the exit code is 128.

The test case reflects what we are observing in production - a few pods all on the same node fail to start with this message (and exit code). That they are all on the same node suggests that it is a shared resource having issues, but we cannot match the error with any of our own daemonsets/infra, so our working assumption is that this is a problem at the kubelet/cluster layer. We definitely see that this is a transient issue though - within a few seconds the pods are able to start successfully.

Rather than treat `ContainerCannotRun` in its entirety as a transient state - we have definitely seen cases where the issue _is_ fatal, e.g. missing executables - instead treat only the 128 exit code as transient. I cannot find exactly where this exit code is coming from, which is pretty dissatisfying, but I think it's acceptable to make this very targetted change based only on our real world observations, to improve the user experience.

**What could go wrong?**

We treat other, genuinely fatal `ContainerCannotRun` conditions with a 128 exit code as transient, and Krane takes longer than today to declare the rollout of those resources as failed or doomed.
