### PR TITLE
fix: add an override for Job in cluster resource discovery

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -85,7 +85,8 @@ module Krane
     def version_for_kind(versions, kind)
       # Override list for kinds that don't appear in the lastest version of a group
       version_override = { "CronJob" => "v1beta1", "VolumeAttachment" => "v1beta1",
-                           "CSIDriver" => "v1beta1", "Ingress" => "v1beta1", "CSINode" => "v1beta1" }
+                           "CSIDriver" => "v1beta1", "Ingress" => "v1beta1",
+                           "CSINode" => "v1beta1", "Job" => "v1" }
 
       pattern = /v(?<major>\d+)(?<pre>alpha|beta)?(?<minor>\d+)?/
       latest = versions.sort_by do |version|

--- a/test/fixtures/for_unit_tests/api_versions.txt
+++ b/test/fixtures/for_unit_tests/api_versions.txt
@@ -14,6 +14,7 @@ autoscaling/v2beta1
 autoscaling/v2beta2
 batch/v1
 batch/v1beta1
+batch/v2alpha1
 certificates.k8s.io/v1beta1
 coordination.k8s.io/v1
 coordination.k8s.io/v1beta1

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -50,7 +50,18 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     kinds = crd.prunable_resources(namespaced: true)
 
     assert_equal(kinds.length, 25)
-    %w(ConfigMap CronJob Deployment batch/v1/Job).each do |expected_kind|
+    %w(ConfigMap CronJob Deployment).each do |expected_kind|
+      assert kinds.one? { |k| k.include?(expected_kind) }
+    end
+  end
+
+  def test_prunable_namespaced_resources_apply_group_version_kind_overrides
+    Krane::Kubectl.any_instance.stubs(:run).with("api-versions", attempts: 5, use_namespace: false)
+      .returns([api_versions_full_response, "", stub(success?: true)])
+    crd = mocked_cluster_resource_discovery(api_resources_namespaced_full_response, namespaced: true)
+    kinds = crd.prunable_resources(namespaced: true)
+
+    %w(batch/v1/Job extensions/v1beta1/Ingress).each do |expected_kind|
       assert kinds.one? { |k| k.include?(expected_kind) }
     end
   end

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -50,7 +50,7 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     kinds = crd.prunable_resources(namespaced: true)
 
     assert_equal(kinds.length, 25)
-    %w(ConfigMap CronJob Deployment).each do |expected_kind|
+    %w(ConfigMap CronJob Deployment batch/v1/Job).each do |expected_kind|
       assert kinds.one? { |k| k.include?(expected_kind) }
     end
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
...
fix the error `no matches for kind "Job" in version "batch/v2alpha1"` https://github.com/Shopify/krane/issues/687

**How is this accomplished?**
adding an override for Job in cluster resource discovery

**What could go wrong?**
...
