### PR TITLE
Fix deprecation warning running parallel tests

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -41,7 +41,7 @@ bundle exec rake unit_test
 print_header "Run Non-Parallel Integration Tests"
 bundle exec rake serial_integration_test
 
-print_header "Run Parallel Integration Tests (N=$PARALLELISM)"
-PARALLELIZE_ME=1 N=$PARALLELISM bundle exec rake integration_test
+print_header "Run Parallel Integration Tests (MT_CPU=$PARALLELISM)"
+PARALLELIZE_ME=1 MT_CPU=$PARALLELISM bundle exec rake integration_test
 
 test $err -eq 0

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("yard")
 
   # Test framework
-  spec.add_development_dependency("minitest", "~> 5.0")
+  spec.add_development_dependency("minitest", "~> 5.12")
   spec.add_development_dependency("minitest-stub-const", "~> 0.6")
   spec.add_development_dependency("minitest-reporters")
   spec.add_development_dependency("mocha", "~> 1.5")


### PR DESCRIPTION
Spotted in the CI logs:

`DEPRECATED: use MT_CPU instead of N for parallel test runs`