### PR TITLE
Stop deploys if ClusterResourceDiscovery's kubectl calls fail

### DIFF
--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -559,9 +559,20 @@ class SerialDeployTest < Krane::IntegrationTest
     ])
   end
 
-  def test_resource_discovery_stops_deploys_when_kubectl_errs
+  def test_resource_discovery_stops_deploys_when_fetch_resources_kubectl_errs
     failure_msg = "Stubbed failure reason"
     Krane::ClusterResourceDiscovery.any_instance.expects(:fetch_resources).raises(Krane::FatalKubeAPIError, failure_msg)
+    assert_deploy_failure(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]))
+
+    assert_logs_match_all([
+      "Result: FAILURE",
+      failure_msg,
+    ], in_order: true)
+  end
+
+  def test_resource_discovery_stops_deploys_when_fetch_crds_kubectl_errs
+    failure_msg = "Stubbed failure reason"
+    Krane::ClusterResourceDiscovery.any_instance.expects(:crds).raises(Krane::FatalKubeAPIError, failure_msg)
     assert_deploy_failure(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]))
 
     assert_logs_match_all([

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -558,4 +558,15 @@ class SerialDeployTest < Krane::IntegrationTest
       "#{add_unique_prefix_for_test('my-first-mail')} (#{add_unique_prefix_for_test('Mail')})",
     ])
   end
+
+  def test_resource_discovery_stops_deploys_when_kubectl_errs
+    failure_msg = "Stubbed failure reason"
+    Krane::ClusterResourceDiscovery.any_instance.expects(:fetch_resources).raises(Krane::FatalKubeAPIError, failure_msg)
+    assert_deploy_failure(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"]))
+
+    assert_logs_match_all([
+      "Result: FAILURE",
+      failure_msg,
+    ], in_order: true)
+  end
 end

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -6,8 +6,9 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
 
   def test_fetch_resources_failure
     crd = mocked_cluster_resource_discovery(nil, success: false)
-    resources = crd.fetch_resources
-    assert_equal(resources, [])
+    assert_raises_message(Krane::FatalKubeAPIError, "Error retrieving api-resources:") do
+      crd.fetch_resources
+    end
   end
 
   def test_fetch_resources_not_namespaced


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Currently we allow the kubectl calls in ClusterResourceDiscovery to fail with only warnings logged. However, this leads to funky behavior. We should have consistent and safe behavior. 

Closes: https://github.com/Shopify/krane/issues/681

**How is this accomplished?**
Raise an error to stop the deploy if kubectl calls fail. 

**What could go wrong?**
We could block deploys when the cluster is partially unhealthy (e.g. the external metric server is down).