### PR TITLE
Set new Github team as code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @KnVerey @dturn @Shopify/production-excellence @DazWorrall
+* @Shopify/krane


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Change our codeowners to the [new Github team](https://github.com/orgs/Shopify/teams/krane/members) instead of naming the individual maintainers + ProdX. Danny and I both feel that having an automatic personal tag as soon as a PR gets opened is causing noise and confusion. It makes it unclear that internal contributors should still be selecting reviewers, and impossible for me to tell as a non-ProdX member whether my review is actually desired.

@Shopify/krane 

**How is this accomplished?**
Create a Github team and change the file.

**What could go wrong?**
This could still be annoying.
