### PR TITLE
Set the Ruby version in dev.yml according to #693

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 ---
 name: krane
 up:
-  - ruby: 2.4.6 # Matches gemspec
+  - ruby: 2.6.5 # Matches gemspec
   - bundler
   - homebrew:
     - Caskroom/cask/minikube


### PR DESCRIPTION


**What are you trying to accomplish with this PR?**
Solving version conflict between dev and bundler, making `dev up` complete successfully again.

**How is this accomplished?**
Setting the Ruby version in dev.yml. This seems to be an oversight in https://github.com/Shopify/krane/pull/693.

**What could go wrong?**
/
