### PR TITLE
fix various Ruby deprecation warnings

### DIFF
--- a/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,5 +1,3 @@
-# Recommended rubocop version: ~> 0.78.0
-
 AllCops:
   Exclude:
   - 'db/schema.rb'
@@ -77,13 +75,6 @@ Style/BlockDelimiters:
   - lambda
   - proc
   - it
-
-Style/BracesAroundHashParameters:
-  EnforcedStyle: no_braces
-  SupportedStyles:
-  - braces
-  - no_braces
-  - context_dependent
 
 Layout/CaseIndentation:
   EnforcedStyle: end

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -9,14 +9,21 @@ steps:
       - bundle exec rubocop
     dependencies:
       - bundler
-  - label: 'Run Test Suite (:kubernetes: 1.17-latest :ruby: 2.6)'
+  - label: 'Run Test Suite (:kubernetes: 1.17-latest :ruby: 2.7)'
     command: bin/ci
     agents:
       queue: k8s-ci
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.17-latest
-      RUBY_VERSION: "2.6"
+      RUBY_VERSION: "2.7"
+  - label: 'Run Test Suite (:kubernetes: 1.17-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.17-latest
   - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
     command: bin/ci
     agents:

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 ---
 name: krane
 up:
-  - ruby: 2.4.6 # Matches gemspec
+  - ruby: 2.5.7 # Matches gemspec
   - bundler
   - homebrew:
     - Caskroom/cask/minikube

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -116,8 +116,8 @@ module Krane
     # Runs the task, returning a boolean representing success or failure
     #
     # @return [Boolean]
-    def run(*args)
-      run!(*args)
+    def run(**args)
+      run!(**args)
       true
     rescue FatalDeploymentError
       false

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -46,8 +46,8 @@ module Krane
     # Runs the task, returning a boolean representing success or failure
     #
     # @return [Boolean]
-    def run(*args)
-      run!(*args)
+    def run(**args)
+      run!(**args)
       true
     rescue FatalDeploymentError
       false

--- a/lib/krane/kubernetes_resource/custom_resource.rb
+++ b/lib/krane/kubernetes_resource/custom_resource.rb
@@ -62,7 +62,7 @@ module Krane
       kind
     end
 
-    def validate_definition(*)
+    def validate_definition(*, **)
       super
 
       @crd.validate_rollout_conditions

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -66,7 +66,7 @@ module Krane
       @rollout_conditions = nil
     end
 
-    def validate_definition(*)
+    def validate_definition(*, **)
       super
 
       validate_rollout_conditions

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -97,7 +97,7 @@ module Krane
       progress_condition.present? ? deploy_failing_to_progress? : super
     end
 
-    def validate_definition(*)
+    def validate_definition(*, **)
       super
 
       unless REQUIRED_ROLLOUT_TYPES.include?(required_rollout) || percent?(required_rollout)

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -191,7 +191,7 @@ module Krane
     def min_available_replicas
       if percent?(required_rollout)
         (desired_replicas * required_rollout.to_i / 100.0).ceil
-      elsif max_unavailable =~ /%/
+      elsif max_unavailable.is_a?(String) && max_unavailable =~ /%/
         (desired_replicas * (100 - max_unavailable.to_i) / 100.0).ceil
       else
         desired_replicas - max_unavailable.to_i

--- a/lib/krane/render_task.rb
+++ b/lib/krane/render_task.rb
@@ -24,8 +24,8 @@ module Krane
     # Runs the task, returning a boolean representing success or failure
     #
     # @return [Boolean]
-    def run(*args)
-      run!(*args)
+    def run(**args)
+      run!(**args)
       true
     rescue Krane::FatalDeploymentError
       false

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -39,8 +39,8 @@ module Krane
     # Runs the task, returning a boolean representing success or failure
     #
     # @return [Boolean]
-    def run(*args)
-      perform!(*args)
+    def run(**args)
+      perform!(**args)
       true
     rescue FatalDeploymentError
       false

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -34,8 +34,8 @@ module Krane
     # Runs the task, returning a boolean representing success or failure
     #
     # @return [Boolean]
-    def run(*args)
-      run!(*args)
+    def run(**args)
+      run!(**args)
       true
     rescue DeploymentTimeoutError, FatalDeploymentError
       false

--- a/lib/krane/statsd.rb
+++ b/lib/krane/statsd.rb
@@ -35,10 +35,10 @@ module Krane
         end
 
         metric ||= "#{method_name}.duration"
-        self::InstrumentationProxy.send(:define_method, method_name) do |*args, &block|
+        self::InstrumentationProxy.send(:define_method, method_name) do |*args, **kwargs, &block|
           begin
             start_time = Time.now.utc
-            super(*args, &block)
+            super(*args, **kwargs, &block)
           rescue
             error = true
             raise

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -37,7 +37,7 @@ module FixtureDeployHelper
     success = false
     Dir.mktmpdir("fixture_dir") do |target_dir|
       write_fixtures_to_dir(fixtures, target_dir)
-      success = deploy_dirs(target_dir, args)
+      success = deploy_dirs(target_dir, **args)
     end
     success
   end
@@ -124,7 +124,7 @@ module FixtureDeployHelper
       printer.print(File.new(filename, "a+"), {})
       deploy_result
     else
-      deploy_dirs_without_profiling(dirs, args)
+      deploy_dirs_without_profiling(dirs, **args)
     end
   end
 

--- a/test/helpers/mock_resource.rb
+++ b/test/helpers/mock_resource.rb
@@ -4,7 +4,7 @@ MockResource = Struct.new(:id, :hits_to_complete, :status) do
   self::SYNC_DEPENDENCIES = []
   self::SENSITIVE_TEMPLATE_CONTENT = false
 
-  def debug_message(*)
+  def debug_message(*, **)
     @debug_message
   end
 

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -18,7 +18,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     mock.expects(:create_pod).raises(Kubeclient::HttpError.new("409", "Pod with same name exists", {}))
     task_runner.instance_variable_set(:@kubeclient, mock)
 
-    result = task_runner.run(run_params(verify_result: false))
+    result = task_runner.run(**run_params(verify_result: false))
     assert_task_run_failure(result)
 
     assert_logs_match_all([
@@ -36,7 +36,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     task_runner = build_task_runner(ns: bad_ns)
 
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(run_params)
+      result = task_runner.run(**run_params)
       assert_task_run_failure(result)
     end
 
@@ -53,7 +53,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     task_runner = build_task_runner
 
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(run_params.merge(verify_result: false))
+      result = task_runner.run(**run_params.merge(verify_result: false))
       assert_task_run_success(result)
     end
 
@@ -70,7 +70,7 @@ class SerialTaskRunTest < Krane::IntegrationTest
     task_runner = build_task_runner(global_timeout: 0)
 
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(run_params.merge(arguments: ["sleep 5"]))
+      result = task_runner.run(**run_params.merge(arguments: ["sleep 5"]))
       assert_task_run_failure(result, :timed_out)
     end
 

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -1546,7 +1546,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
   def test_deploy_fails_if_context_is_invalid
     task_runner = build_deploy_runner(context: "unknown")
-    assert_task_run_failure(task_runner.run(run_params))
+    assert_task_run_failure(task_runner.run(**run_params))
 
     assert_logs_match_all([
       "Context unknown missing from your kubeconfig file(s)",
@@ -1555,7 +1555,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
 
   def test_deploy_fails_if_namespace_is_invalid
     task_runner = build_deploy_runner(ns: "unknown")
-    assert_task_run_failure(task_runner.run(run_params))
+    assert_task_run_failure(task_runner.run(**run_params))
 
     assert_logs_match_all([
       "Could not find Namespace: unknown in Context: minikube",

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -9,7 +9,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
     task_runner = build_task_runner
     assert_nil(task_runner.pod_name)
-    result = task_runner.run(run_params(verify_result: false))
+    result = task_runner.run(**run_params(verify_result: false))
     assert_task_run_success(result)
 
     assert_logs_match_all([
@@ -30,7 +30,7 @@ class RunnerTaskTest < Krane::IntegrationTest
     deploy_task_template
 
     task_runner = build_task_runner(global_timeout: 5)
-    result = task_runner.run(run_params(log_lines: 8, log_interval: 1))
+    result = task_runner.run(**run_params(log_lines: 8, log_interval: 1))
     assert_task_run_failure(result, :timed_out)
 
     assert_logs_match_all([
@@ -45,7 +45,7 @@ class RunnerTaskTest < Krane::IntegrationTest
     deploy_task_template
 
     task_runner = build_task_runner
-    result = task_runner.run(run_params.merge(arguments: ["/not/a/command"]))
+    result = task_runner.run(**run_params.merge(arguments: ["/not/a/command"]))
     assert_task_run_failure(result)
 
     assert_logs_match_all([
@@ -67,7 +67,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
     task_runner = build_task_runner
     assert_nil(task_runner.pod_name)
-    result = task_runner.run(run_params(log_lines: 8, log_interval: 0.25))
+    result = task_runner.run(**run_params(log_lines: 8, log_interval: 0.25))
     assert_task_run_success(result)
 
     assert_logs_match_all([
@@ -108,7 +108,7 @@ class RunnerTaskTest < Krane::IntegrationTest
     end
     deleter_thread.abort_on_exception = true
 
-    result = task_runner.run(run_params(log_lines: 20, log_interval: 1))
+    result = task_runner.run(**run_params(log_lines: 20, log_interval: 1))
     assert_task_run_failure(result)
 
     assert_logs_match_all([
@@ -123,7 +123,7 @@ class RunnerTaskTest < Krane::IntegrationTest
   def test_run_with_verify_result_neither_misses_nor_duplicates_logs_across_pollings
     deploy_task_template
     task_runner = build_task_runner
-    result = task_runner.run(run_params(log_lines: 5_000, log_interval: 0.0005))
+    result = task_runner.run(**run_params(log_lines: 5_000, log_interval: 0.0005))
     assert_task_run_success(result)
 
     logging_assertion do |all_logs|
@@ -148,7 +148,7 @@ class RunnerTaskTest < Krane::IntegrationTest
     end
 
     task_runner = build_task_runner
-    assert_task_run_success(task_runner.run(run_params))
+    assert_task_run_success(task_runner.run(**run_params))
 
     assert_logs_match_all([
       "Phase 1: Initializing task",
@@ -163,7 +163,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
     task_runner = build_task_runner
     assert_raises(Krane::FatalDeploymentError) do
-      task_runner.run!(run_params.merge(arguments: ["/not/a/command"]))
+      task_runner.run!(**run_params.merge(arguments: ["/not/a/command"]))
     end
 
     assert_logs_match_all([
@@ -180,7 +180,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
   def test_run_fails_if_context_is_invalid
     task_runner = build_task_runner(context: "unknown")
-    assert_task_run_failure(task_runner.run(run_params))
+    assert_task_run_failure(task_runner.run(**run_params))
 
     assert_logs_match_all([
       "Initializing task",
@@ -193,7 +193,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
   def test_run_fails_if_namespace_is_missing
     task_runner = build_task_runner(ns: "missing")
-    assert_task_run_failure(task_runner.run(run_params))
+    assert_task_run_failure(task_runner.run(**run_params))
 
     assert_logs_match_all([
       "Initializing task",
@@ -233,7 +233,7 @@ class RunnerTaskTest < Krane::IntegrationTest
 
   def test_run_with_template_missing
     task_runner = build_task_runner
-    assert_task_run_failure(task_runner.run(run_params))
+    assert_task_run_failure(task_runner.run(**run_params))
     message = "Pod template `hello-cloud-template-runner` not found in namespace `#{@namespace}`, " \
       "context `#{KubeclientHelper::TEST_CONTEXT}`"
     assert_logs_match_all([
@@ -242,7 +242,7 @@ class RunnerTaskTest < Krane::IntegrationTest
     ], in_order: true)
 
     assert_raises_message(Krane::RunnerTask::TaskTemplateMissingError, message) do
-      task_runner.run!(run_params)
+      task_runner.run!(**run_params)
     end
   end
 
@@ -253,11 +253,11 @@ class RunnerTaskTest < Krane::IntegrationTest
     end
 
     task_runner = build_task_runner
-    assert_task_run_failure(task_runner.run(run_params))
+    assert_task_run_failure(task_runner.run(**run_params))
     message = "Pod spec does not contain a template container called 'task-runner'"
 
     assert_raises_message(Krane::TaskConfigurationError, message) do
-      task_runner.run!(run_params)
+      task_runner.run!(**run_params)
     end
 
     assert_logs_match_all([

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -201,7 +201,7 @@ module Krane
     def build_runless_kubectl
       obj = Krane::Kubectl.new(task_config: task_config(namespace: 'test'),
         log_failure_by_default: false)
-      def obj.run(*,**)
+      def obj.run(*, **)
         ["", "", SystemExit.new(0)]
       end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -201,7 +201,7 @@ module Krane
     def build_runless_kubectl
       obj = Krane::Kubectl.new(task_config: task_config(namespace: 'test'),
         log_failure_by_default: false)
-      def obj.run(*)
+      def obj.run(*,**)
         ["", "", SystemExit.new(0)]
       end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Remove Ruby deprecation warnings, even during testsuite run.

**How is this accomplished?**

Mostly just using backwards compatible syntax that doesn't emit warnings in newer Rubies. I had to add an additional check where Ruby's behaviour changed: https://github.com/Shopify/krane/pull/710/files#diff-590b908e9e2a650e8308c57e958bdb1aR194

**What could go wrong?**
I don't see what could, apart from funny edge cases in old Ruby versions. 

**Notes**
With https://github.com/Shopify/krane/pull/675 , the tip of https://github.com/abonas/kubeclient , and recursive-open-struct 1.1.1 the testsuite passes for me and only emits one deprecation warning. It's in mocha though and a doozy to fix.  I will test a full deployment using that version combination shortly.

The CLA has not been signed yet, but it's in progress.
