### PR TITLE
Update 1.0 Upgrade doc instructions to use --filenames instead of --filename

### DIFF
--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -119,7 +119,7 @@ Old flag | New flag | Comments
 --skip-wait | --verify-result=true |
 --allow-protected-ns | --protected-namespaces=default,kube-system,kube-public | Added the ability to specify which namespaces are protected
 --no-prune | --prune=true |
---template-dir | -f, --filename | Makes all krane commands accept this argument, which is now required for the deploy task
+--template-dir | -f, --filenames | Makes all krane commands accept this argument, which is now required for the deploy task
 --verbose-log-prefix | --verbose-log-prefix |
 --max-watch-seconds=seconds | --global-timeout=300s | Changed flag name and default value to be a duration (expressed using strings like "300s" or "1h")
 --selector | --selector |


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
`krane deploy` takes in the option `--filenames`, not `--filename`. Fix similar to: https://github.com/Shopify/krane/pull/659

**How is this accomplished?**
Doc change. 

**What could go wrong?**
