### PR TITLE
Add printing of kubectl error message

### DIFF
--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -154,7 +154,7 @@ module Krane
           log_pruning(out) if prune
         else
           record_apply_failure(err, resources: resources)
-          raise FatalDeploymentError, "Command failed: #{Shellwords.join(command)}"
+          raise FatalDeploymentError, "Command failed: #{Shellwords.join(command)}:\n#{err}"
         end
       end
     end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Currently if there is some error applying a manifest happening at the `kubectl apply` call, this error will get swallowed by krane. It is reported that an error occurred, but not what the error is. 

This behaviour is making it unfeasible to debug underlying issues, for example permission issues on the (service) account used to run krane in a CD environment.

Example:
```
[INFO][2020-04-20 14:21:46 +0000][staging][someapp-staging]	
[INFO][2020-04-20 14:21:46 +0000][staging][someapp-staging]	------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2020-04-20 14:21:46 +0000][staging][someapp-staging]	Command failed: apply -f /tmp/d20200420-9481-sf4wgt --prune --all --prune-whitelist\=/v1/configmap --prune-whitelist\=/v1/endpoints --prune-whitelist\=/v1/event --prune-whitelist\=/v1/limitrange --prune-whitelist\=/v1/persistentvolumeclaim --prune-whitelist\=/v1/pod --prune-whitelist\=/v1/podtemplate --prune-whitelist\=/v1/replicationcontroller --prune-whitelist\=/v1/resourcequota --prune-whitelist\=/v1/secret --prune-whitelist\=/v1/serviceaccount --prune-whitelist\=/v1/service --prune-whitelist\=apps/v1/daemonset --prune-whitelist\=apps/v1/deployment --prune-whitelist\=apps/v1/replicaset --prune-whitelist\=apps/v1/statefulset --prune-whitelist\=autoscaling/v2beta1/horizontalpodautoscaler --prune-whitelist\=batch/v1beta1/cronjob --prune-whitelist\=batch/v1/job --prune-whitelist\=certmanager.k8s.io/v1alpha1/certificaterequest --prune-whitelist\=certmanager.k8s.io/v1alpha1/certificate --prune-whitelist\=certmanager.k8s.io/v1alpha1/challenge --prune-whitelist\=certmanager.k8s.io/v1alpha1/issuer --prune-whitelist\=certmanager.k8s.io/v1alpha1/order --prune-whitelist\=cloud.google.com/v1beta1/backendconfig --prune-whitelist\=crd.projectcalico.org/v1/networkpolicy --prune-whitelist\=extensions/v1beta1/ingress --prune-whitelist\=internal.autoscaling.k8s.io/v1alpha1/capacityrequest --prune-whitelist\=networking.gke.io/v1beta1/managedcertificate --prune-whitelist\=nodemanagement.gke.io/v1alpha1/updateinfo --prune-whitelist\=policy/v1beta1/poddisruptionbudget --prune-whitelist\=rbac.authorization.k8s.io/v1/rolebinding --prune-whitelist\=rbac.authorization.k8s.io/v1/role --prune-whitelist\=scalingpolicy.kope.io/v1alpha1/scalingpolicy
[FATAL][2020-04-20 14:21:46 +0000][staging][someapp-staging]	
```
Not helpful, as even if a user would have access to the system/environment to manually replicate the `kubectl apply` call, krane already cleaned up the temp dir.

With this change:
```
[INFO][2020-04-20 15:44:40 +0000][staging][someapp-staging]	------------------------------------------Result: FAILURE-------------------------------------------
[FATAL][2020-04-20 15:44:40 +0000][staging][someapp-staging]	Command failed: apply -f /tmp/d20200420-757-1v2j9wa --prune --all --prune-whitelist\=/v1/configmap --prune-whitelist\=/v1/endpoints --prune-whitelist\=/v1/event --prune-whitelist\=/v1/limitrange --prune-whitelist\=/v1/persistentvolumeclaim --prune-whitelist\=/v1/pod --prune-whitelist\=/v1/podtemplate --prune-whitelist\=/v1/replicationcontroller --prune-whitelist\=/v1/resourcequota --prune-whitelist\=/v1/secret --prune-whitelist\=/v1/serviceaccount --prune-whitelist\=/v1/service --prune-whitelist\=apps/v1/daemonset --prune-whitelist\=apps/v1/deployment --prune-whitelist\=apps/v1/replicaset --prune-whitelist\=apps/v1/statefulset --prune-whitelist\=autoscaling/v2beta1/horizontalpodautoscaler --prune-whitelist\=batch/v1beta1/cronjob --prune-whitelist\=batch/v1/job --prune-whitelist\=certmanager.k8s.io/v1alpha1/certificaterequest --prune-whitelist\=certmanager.k8s.io/v1alpha1/certificate --prune-whitelist\=certmanager.k8s.io/v1alpha1/challenge --prune-whitelist\=certmanager.k8s.io/v1alpha1/issuer --prune-whitelist\=certmanager.k8s.io/v1alpha1/order --prune-whitelist\=cloud.google.com/v1beta1/backendconfig --prune-whitelist\=crd.projectcalico.org/v1/networkpolicy --prune-whitelist\=extensions/v1beta1/ingress --prune-whitelist\=internal.autoscaling.k8s.io/v1alpha1/capacityrequest --prune-whitelist\=networking.gke.io/v1beta1/managedcertificate --prune-whitelist\=nodemanagement.gke.io/v1alpha1/updateinfo --prune-whitelist\=policy/v1beta1/poddisruptionbudget --prune-whitelist\=rbac.authorization.k8s.io/v1/rolebinding --prune-whitelist\=rbac.authorization.k8s.io/v1/role --prune-whitelist\=scalingpolicy.kope.io/v1alpha1/scalingpolicy:
error: error pruning namespaced object networking.gke.io/v1beta1, kind=managedcertificate: managedcertificates.networking.gke.io is forbidden: user "someserviceaccount@shopify-someapp-staging.iam.gserviceaccount.com" cannot list resource "managedcertificates" in api group "networking.gke.io" in the namespace "someapp-staging"
[FATAL][2020-04-20 15:44:40 +0000][staging][someapp-staging]	
```

**How is this accomplished?**
Add the collected error to the message presented to the user.

**What could go wrong?**
Leaking sensitive information, maybe, somehow, eventually? 
