### PR TITLE
Allow to set image tag for task runner

### DIFF
--- a/lib/krane/container_overrides.rb
+++ b/lib/krane/container_overrides.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+module Krane
+  class ContainerOverrides
+    attr_reader :command, :arguments, :env_vars, :image_tag
+
+    def initialize(command: nil, arguments: nil, env_vars: [], image_tag: nil)
+      @command = command
+      @arguments = arguments
+      @env_vars = env_vars
+      @image_tag = image_tag
+    end
+
+    def run!(container)
+      container.command = command if command
+      container.args = arguments if arguments
+
+      if image_tag
+        image = container.image
+        base_image, _old_tag = image.split(':')
+        new_image = "#{base_image}:#{image_tag}"
+
+        container.image = new_image
+      end
+
+      env_args = env_vars.map do |env|
+        key, value = env.split('=', 2)
+        { name: key, value: value }
+      end
+      container.env ||= []
+      container.env = container.env.map(&:to_h) + env_args
+    end
+  end
+end

--- a/lib/krane/container_overrides.rb
+++ b/lib/krane/container_overrides.rb
@@ -10,7 +10,7 @@ module Krane
       @image_tag = image_tag
     end
 
-    def run!(container)
+    def apply!(container)
       container.command = command if command
       container.args = arguments if arguments
 

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -179,7 +179,7 @@ module Krane
         raise TaskConfigurationError, message
       end
 
-      container_overrides.run!(container)
+      container_overrides.apply!(container)
     end
 
     def ensure_valid_restart_policy!(template, verify)

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -9,6 +9,7 @@ require 'krane/resource_watcher'
 require 'krane/kubernetes_resource'
 require 'krane/kubernetes_resource/pod'
 require 'krane/runner_task_config_validator'
+require 'krane/container_overrides'
 
 module Krane
   # Run a pod that exits upon completing a task
@@ -50,7 +51,7 @@ module Krane
     # @param verify_result [Boolean] Wait for completion and verify pod success
     #
     # @return [nil]
-    def run!(template:, command:, arguments:, env_vars: [], verify_result: true)
+    def run!(template:, command:, arguments:, env_vars: [], image_tag: nil, verify_result: true)
       start = Time.now.utc
       @logger.reset
 
@@ -59,8 +60,13 @@ module Krane
       @logger.info("Validating configuration")
       verify_config!(template)
       @logger.info("Using namespace '#{@namespace}' in context '#{@context}'")
-
-      pod = build_pod(template, command, arguments, env_vars, verify_result)
+      container_overrides = ContainerOverrides.new(
+        command: command,
+        arguments: arguments,
+        env_vars: env_vars,
+        image_tag: image_tag
+      )
+      pod = build_pod(template, container_overrides, verify_result)
       validate_pod(pod)
 
       @logger.phase_heading("Running pod")
@@ -98,11 +104,11 @@ module Krane
       raise FatalDeploymentError, msg
     end
 
-    def build_pod(template_name, command, args, env_vars, verify_result)
+    def build_pod(template_name, container_overrides, verify_result)
       task_template = get_template(template_name)
       @logger.info("Using template '#{template_name}'")
       pod_template = build_pod_definition(task_template)
-      set_container_overrides!(pod_template, command, args, env_vars)
+      set_container_overrides!(pod_template, container_overrides)
       ensure_valid_restart_policy!(pod_template, verify_result)
       Pod.new(namespace: @namespace, context: @context, logger: @logger, stream_logs: true,
                     definition: pod_template.to_hash.deep_stringify_keys, statsd_tags: [])
@@ -165,7 +171,7 @@ module Krane
       pod_definition
     end
 
-    def set_container_overrides!(pod_definition, command, args, env_vars)
+    def set_container_overrides!(pod_definition, container_overrides)
       container = pod_definition.spec.containers.find { |cont| cont.name == 'task-runner' }
       if container.nil?
         message = "Pod spec does not contain a template container called 'task-runner'"
@@ -173,15 +179,7 @@ module Krane
         raise TaskConfigurationError, message
       end
 
-      container.command = command if command
-      container.args = args if args
-
-      env_args = env_vars.map do |env|
-        key, value = env.split('=', 2)
-        { name: key, value: value }
-      end
-      container.env ||= []
-      container.env = container.env.map(&:to_h) + env_args
+      container_overrides.run!(container)
     end
 
     def ensure_valid_restart_policy!(template, verify)

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -284,6 +284,24 @@ class RunnerTaskTest < Krane::IntegrationTest
     ], in_order: true)
   end
 
+  def test_run_adds_custom_image_tag_provided_to_the_task_container
+    deploy_task_template
+
+    task_runner = build_task_runner
+    result = task_runner.run(
+      template: 'hello-cloud-template-runner',
+      command: ['/bin/sh', '-c'],
+      arguments: ['echo "Hello World"'],
+      image_tag: 'latest'
+    )
+    assert_task_run_success(result)
+
+    pods = kubeclient.get_pods(namespace: @namespace)
+    assert_equal(1, pods.length, "Expected 1 pod to exist, found #{pods.length}")
+    container = pods.first.spec.containers.find { |cont| cont.name == 'task-runner' }
+    assert_equal('busybox:latest', container.image, "Container image should have been upadted")
+  end
+
   private
 
   def deploy_unschedulable_template

--- a/test/unit/krane/container_overrides_test.rb
+++ b/test/unit/krane/container_overrides_test.rb
@@ -7,37 +7,64 @@ module Krane
       super
       @container = Kubeclient::Resource.new(
         name: "task-runner",
-        image: "gcc:3.2",
+        image: "busybox",
         command: ["sh", "-c", "echo 'Hello from the command runner!' "],
         env: [{ name: "CONFIG", value: "NUll" }],
         resources: {},
       )
     end
 
-    def test_updates_command
+    def test_updates_command_if_command_is_provided
       override = Krane::ContainerOverrides.new(command: ['/bin/sh', '-c'])
       override.run!(@container)
       assert_equal(['/bin/sh', '-c'], @container.command)
     end
 
-    def test_updates_image
-      override = Krane::ContainerOverrides.new(image_tag: '4.9')
+    def test_does_not_update_command_if_not_provided
+      override = Krane::ContainerOverrides.new
       override.run!(@container)
-      assert_equal('gcc:4.9', @container.image)
+      assert_equal(["sh", "-c", "echo 'Hello from the command runner!' "], @container.command)
     end
 
-    def test_updates_args
+    def test_updates_image_tag_if_provided
+      override = Krane::ContainerOverrides.new(image_tag: 'latest')
+      override.run!(@container)
+      assert_equal('busybox:latest', @container.image)
+    end
+
+    def test_does_not_updates_image_tag_if_not_provided
+      override = Krane::ContainerOverrides.new
+      override.run!(@container)
+      assert_equal('busybox', @container.image)
+    end
+
+    def test_updates_args_if_provided
       override = Krane::ContainerOverrides.new(arguments: ['ping'])
       override.run!(@container)
       assert_equal(['ping'], @container.args)
     end
 
-    def test_updates_env
+    def test_does_not_updates_args_if_not_provided
+      override = Krane::ContainerOverrides.new
+      override.run!(@container)
+      assert_nil(@container.args)
+    end
+
+    def test_updates_env_if_provided
       override = Krane::ContainerOverrides.new(env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
       override.run!(@container)
       expectd_env = [
         Kubeclient::Resource.new(name: "CONFIG", value: "NUll"),
         Kubeclient::Resource.new(name: "MY_CUSTOM_VARIABLE", value: "MITTENS"),
+      ]
+      assert_equal(expectd_env, @container.env)
+    end
+
+    def test_does_not_updates_env_if_not_provided
+      override = Krane::ContainerOverrides.new
+      override.run!(@container)
+      expectd_env = [
+        Kubeclient::Resource.new(name: "CONFIG", value: "NUll"),
       ]
       assert_equal(expectd_env, @container.env)
     end

--- a/test/unit/krane/container_overrides_test.rb
+++ b/test/unit/krane/container_overrides_test.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Krane
+  class ContainerOverridesTest < Krane::TestCase
+    def setup
+      super
+      @container = Kubeclient::Resource.new(
+        name: "task-runner",
+        image: "gcc:3.2",
+        command: ["sh", "-c", "echo 'Hello from the command runner!' "],
+        env: [{ name: "CONFIG", value: "NUll" }],
+        resources: {},
+      )
+    end
+
+    def test_updates_command
+      override = Krane::ContainerOverrides.new(command: ['/bin/sh', '-c'])
+      override.run!(@container)
+      assert_equal(['/bin/sh', '-c'], @container.command)
+    end
+
+    def test_updates_image
+      override = Krane::ContainerOverrides.new(image_tag: '4.9')
+      override.run!(@container)
+      assert_equal('gcc:4.9', @container.image)
+    end
+
+    def test_updates_args
+      override = Krane::ContainerOverrides.new(arguments: ['ping'])
+      override.run!(@container)
+      assert_equal(['ping'], @container.args)
+    end
+
+    def test_updates_env
+      override = Krane::ContainerOverrides.new(env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
+      override.run!(@container)
+      expectd_env = [
+        Kubeclient::Resource.new(name: "CONFIG", value: "NUll"),
+        Kubeclient::Resource.new(name: "MY_CUSTOM_VARIABLE", value: "MITTENS"),
+      ]
+      assert_equal(expectd_env, @container.env)
+    end
+  end
+end

--- a/test/unit/krane/container_overrides_test.rb
+++ b/test/unit/krane/container_overrides_test.rb
@@ -16,43 +16,43 @@ module Krane
 
     def test_updates_command_if_command_is_provided
       override = Krane::ContainerOverrides.new(command: ['/bin/sh', '-c'])
-      override.run!(@container)
+      override.apply!(@container)
       assert_equal(['/bin/sh', '-c'], @container.command)
     end
 
     def test_does_not_update_command_if_not_provided
       override = Krane::ContainerOverrides.new
-      override.run!(@container)
+      override.apply!(@container)
       assert_equal(["sh", "-c", "echo 'Hello from the command runner!' "], @container.command)
     end
 
     def test_updates_image_tag_if_provided
       override = Krane::ContainerOverrides.new(image_tag: 'latest')
-      override.run!(@container)
+      override.apply!(@container)
       assert_equal('busybox:latest', @container.image)
     end
 
     def test_does_not_updates_image_tag_if_not_provided
       override = Krane::ContainerOverrides.new
-      override.run!(@container)
+      override.apply!(@container)
       assert_equal('busybox', @container.image)
     end
 
     def test_updates_args_if_provided
       override = Krane::ContainerOverrides.new(arguments: ['ping'])
-      override.run!(@container)
+      override.apply!(@container)
       assert_equal(['ping'], @container.args)
     end
 
     def test_does_not_updates_args_if_not_provided
       override = Krane::ContainerOverrides.new
-      override.run!(@container)
+      override.apply!(@container)
       assert_nil(@container.args)
     end
 
     def test_updates_env_if_provided
       override = Krane::ContainerOverrides.new(env_vars: ["MY_CUSTOM_VARIABLE=MITTENS"])
-      override.run!(@container)
+      override.apply!(@container)
       expectd_env = [
         Kubeclient::Resource.new(name: "CONFIG", value: "NUll"),
         Kubeclient::Resource.new(name: "MY_CUSTOM_VARIABLE", value: "MITTENS"),
@@ -62,7 +62,7 @@ module Krane
 
     def test_does_not_updates_env_if_not_provided
       override = Krane::ContainerOverrides.new
-      override.run!(@container)
+      override.apply!(@container)
       expectd_env = [
         Kubeclient::Resource.new(name: "CONFIG", value: "NUll"),
       ]


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
When running `activefailover` we usually use the predefined value of the image that is calculated at the deploy time on `Shopify/shopify`. This is great, but when you want to test custom code with having to deploy `Shopify/shopify` is getting very painfully, we have to update multiple `task-runner` templates using `kbctl` and that operation is tedious and error-prone.

By allowing to pass the image to `Krane` we can programmatically make the task of testing changes in core much easier.

This is the PR in `activefailover` that utilize this feature https://github.com/Shopify/activefailover/pull/1353

**How is this accomplished?**
Passing a new keyword argument to `image` with a default value of `nil` so it is backward compatible.

I had to refactor `build_pod` because rubocop was complaining that there were too many positional arguments. I extracted the logic to a new collaborator object `ContainerOverrides`

I think there is room for more improvements, but I rather get some opinions from the maintainers first 😄 


@Shopify/job-patterns
@Shopify/pod-failovers 

