### PR TITLE
Only look up resource constants directly available under the Krane module

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -60,8 +60,8 @@ module Krane
       end
 
       def class_for_kind(kind)
-        if Krane.const_defined?(kind)
-          Krane.const_get(kind)
+        if Krane.const_defined?(kind, false)
+          Krane.const_get(kind, false)
         end
       rescue NameError
         nil


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

I ran into an interesting issue today I thought warranted a PR. I'm using [kubedb](https://kubedb.com/) to launch a Redis instance in my k8s cluster. In addition, I have a constant defined in my project called `Redis`.

The Redis kubedb resource looks something like this:

```yaml
kind: Redis
metadata:
  name: foobar
  namespace: foobar-ns
spec:
  ... more stuff here
```

I tried to deploy using Krane and saw this in the list of discovered resources:

```
[INFO][2020-06-14 13:52:13 -0700]
[INFO][2020-06-14 13:52:13 -0700]	------------------------------------Phase 1: Initializing deploy------------------------------------
[INFO][2020-06-14 13:52:14 -0700]	All required parameters and files are present
[INFO][2020-06-14 13:52:14 -0700]	Discovering resources:
[INFO][2020-06-14 13:52:17 -0700]	  - <lots of resources>
[INFO][2020-06-14 13:52:17 -0700]	  - redis://127.0.0.1:6379/0
[INFO][2020-06-14 13:52:17 -0700]	  - <lots of resources>
```

Hmm, that's surprising. What's that Redis URL doing in there? The deploy then failed with this error:

```
ArgumentError: comparison of Redis with Krane::Secret failed
```

A little digging revealed this method in kubernetes_resource.rb:

```ruby
def class_for_kind(kind)
  if Krane.const_defined?(kind)
    Krane.const_get(kind)
  end
rescue NameError
  nil
end
```

Interestingly, `Krane.const_defined?('Redis')` returns true. The [documentation](https://ruby-doc.org/core-2.7.0/Module.html#method-i-const_defined-3F) for `const_defined?` says it will check for the constant in the module's ancestors (including `Object`) unless a second `false` parameter is passed.

**How is this accomplished?**

Since I assume the intent was to look up constants under the `Krane` module directly, I added the second `false` param in this PR. Note that `const_get` works the same way.

**What could go wrong?**

Well, I suppose anyone who's relying on the old behavior, either implicitly or explicitly, is could experience a deploy failure. However in my opinion, this is a bug.