### PR TITLE
fix #721, adding override for IngressClasses to use v1beta1

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -88,7 +88,8 @@ module Krane
       # Override list for kinds that don't appear in the lastest version of a group
       version_override = { "CronJob" => "v1beta1", "VolumeAttachment" => "v1beta1",
                            "CSIDriver" => "v1beta1", "Ingress" => "v1beta1",
-                           "CSINode" => "v1beta1", "Job" => "v1" }
+                           "CSINode" => "v1beta1", "Job" => "v1",
+                           "IngressClasses" => "v1beta1" }
 
       pattern = /v(?<major>\d+)(?<pre>alpha|beta)?(?<minor>\d+)?/
       latest = versions.sort_by do |version|

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -62,7 +62,7 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     crd = mocked_cluster_resource_discovery(api_resources_namespaced_full_response, namespaced: true)
     kinds = crd.prunable_resources(namespaced: true)
 
-    %w(batch/v1/Job extensions/v1beta1/Ingress networking.k8s.io/v1beta1/IngressClass).each do |expected_kind|
+    %w(batch/v1/Job extensions/v1beta1/Ingress).each do |expected_kind|
       assert kinds.one? { |k| k.include?(expected_kind) }
     end
   end

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -62,7 +62,7 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     crd = mocked_cluster_resource_discovery(api_resources_namespaced_full_response, namespaced: true)
     kinds = crd.prunable_resources(namespaced: true)
 
-    %w(batch/v1/Job extensions/v1beta1/Ingress).each do |expected_kind|
+    %w(batch/v1/Job extensions/v1beta1/Ingress networking.k8s.io/v1beta1/IngressClass).each do |expected_kind|
       assert kinds.one? { |k| k.include?(expected_kind) }
     end
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fix for #721, allow deploying to Kubernetes-1.18+ 

**How is this accomplished?**
Add APIVersion override for kind ingressclasses which only exists in networking.k8s.io/v1beta1, not in latest.


**What could go wrong?**
The override doesn't work.


regards,
strowi