### PR TITLE
Emit StatsD metrics with counts of resources

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -242,6 +242,8 @@ module Krane
         @logger.info("  - #{secret.id} (from ejson)")
       end
 
+      StatsD.client.gauge('discover_resources.count', resources.size, tags: statsd_tags)
+
       resources.sort
     rescue InvalidTemplateError => e
       record_invalid_template(logger: @logger, err: e.message, filename: e.filename,

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -173,6 +173,8 @@ module Krane
         logger.info("  - #{r.id}")
       end
 
+      StatsD.client.gauge('discover_resources.count', resources.size, tags: statsd_tags)
+
       resources.sort
     rescue InvalidTemplateError => e
       record_invalid_template(logger: logger, err: e.message, filename: e.filename, content: e.content)

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -48,6 +48,8 @@ module Krane
 
       predeploy_sequence.each do |resource_type|
         matching_resources = resource_list.select { |r| r.type == resource_type }
+        StatsD.client.gauge('priority_resources.count', matching_resources.size, tags: statsd_tags)
+
         next if matching_resources.empty?
         deploy_resources(matching_resources, verify: true, record_summary: false)
 

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -91,12 +91,15 @@ class SerialDeployTest < Krane::IntegrationTest
     %w(
       Krane.validate_configuration.duration
       Krane.discover_resources.duration
+      Krane.discover_resources.count
       Krane.validate_resources.duration
       Krane.initial_status.duration
       Krane.priority_resources.duration
+      Krane.priority_resources.count
       Krane.apply_all.duration
       Krane.normal_resources.duration
       Krane.all_resources.duration
+
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
       refute_nil metric, "Metric #{expected_metric} not emitted"
@@ -115,9 +118,11 @@ class SerialDeployTest < Krane::IntegrationTest
     %w(
       Krane.validate_configuration.duration
       Krane.discover_resources.duration
+      Krane.discover_resources.count
       Krane.initial_status.duration
       Krane.validate_resources.duration
       Krane.priority_resources.duration
+      Krane.priority_resources.count
       Krane.apply_all.duration
       Krane.normal_resources.duration
       Krane.sync.duration
@@ -141,6 +146,7 @@ class SerialDeployTest < Krane::IntegrationTest
     %w(
       Krane.validate_configuration.duration
       Krane.discover_resources.duration
+      Krane.discover_resources.count
       Krane.initial_status.duration
       Krane.validate_resources.duration
       Krane.apply_all.duration


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

I was looking for a source of resource count for some of our apps, and thought this might be nice to track over time. While you can get stats from the Kube control plane, it's a bit tricky to decipher 'managed' resources (e.g. what lives in source control, or what is rendered and given to apply) from the 'hydrated' resources (e.g. pods from replicasets from a deployment, which is actually what the app or user cares about).

This adds a few StatsD gauges to emit the resource counts at deploy time, it's minimal overhead and I think it's a reasonable proxy for the 'size' of a runtime as the user might consider it.

**How is this accomplished?**

Calling `StatsD.client.gauge`

**What could go wrong?**

Maybe `foo_resources.count` is not clear and people count misinterpret it?