### PR TITLE
Always set a deployment_id, even if the current_sha isn't set

### DIFF
--- a/lib/krane/renderer.rb
+++ b/lib/krane/renderer.rb
@@ -28,6 +28,8 @@ module Krane
         ENV["TASK_ID"]
       elsif current_sha
         current_sha[0...8] + "-#{SecureRandom.hex(4)}"
+      else
+        SecureRandom.hex(8)
       end
     end
 

--- a/test/fixtures/for_unit_tests/deployment_id.yml.erb
+++ b/test/fixtures/for_unit_tests/deployment_id.yml.erb
@@ -1,0 +1,9 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: migrate-<%= deployment_id %>
+spec:
+  containers:
+    - name: migrate
+      image: gcr.io/foobar/api


### PR DESCRIPTION
The deployment_id seems like it should always be present, even if current_sha isn't set. Before this change, deployment_id would be nil if current_sha was not set, which means predeployed pods like migrations and whatnot collide. It doesn't seem like a stretch to just use a random string as a deployment ID if the current deployment ID scheme is just using randomness too, so this adds that as a fallback, and adds a test!

**What could go wrong?**

Pods using `deployment_id` in their name would now start having unique names instead of colliding when `current_sha` is unset. I kind of struggle to contrive a situation where that would matter, and especially at Shopify `TASK_ID` is set by Shipit so it seems unlikely Shopify would be relying on this behaviour. But, it is a change in behaviour. I don't think many folks are running with both `current_sha` and `TASK_ID` unset.
