### PR TITLE
Add a note about pre.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,12 @@
 We've renamed the gem and cli to Krane.
 See our [migration guide](https://github.com/Shopify/krane/blob/master/1.0-Upgrade.md) to help navigate the breaking changes.
 
+## 1.0.0.pre.2
+
+*Enhancements*
+- Relax thor version requirement. ([#731](https://github.com/Shopify/krane/pull/731))
+- Relax googleauth restriction. ([#731](https://github.com/Shopify/krane/pull/731))
+
 ## 1.0.0.pre.1
 
 *Important!*


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Add a note about pre.2 release which is coming from https://github.com/Shopify/krane/pull/731

**How is this accomplished?**

I added it above the pre.1 release notes since it doesn't include all the other changes. I feel like it'd be confusing to have it at the top.

**What could go wrong?**

Lemme know if this is an OK approach