### PR TITLE
Pin k8s 1.16 CI to 1.16.12

### DIFF
--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -23,13 +23,14 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.17-latest
-  - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
+  - label: 'Run Test Suite (:kubernetes: 1.16.12)'
     command: bin/ci
     agents:
       queue: k8s-ci
     env:
       LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.16-latest
+      # Flip this back to v1.16-latest when 1.16.14 comes out (see #733)
+      KUBERNETES_VERSION: v1.16.12
   - label: 'Run Test Suite (:kubernetes: 1.15-latest)'
     command: bin/ci
     agents:


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

There appears to be an issue specific to our CI and k8s v1.16.13 so I'm pinning CI to 1.16.12 in the meantime while we investigate.

**How is this accomplished?**

Edit the shopify-build config.