### PR TITLE
Stop core service from being deployed a priority resource

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -56,7 +56,7 @@ module Krane
     )
 
     def predeploy_sequence
-      default_group = { :group => nil }
+      default_group = { group: nil }
       before_crs = %w(
         ResourceQuota
         NetworkPolicy
@@ -66,13 +66,13 @@ module Krane
         Role
         RoleBinding
         Secret
-      ).map {|r| [r, default_group]}
+      ).map { |r| [r, default_group] }
 
       after_crs = %w(
         Pod
-      ).map {|r| [r, default_group]}
+      ).map { |r| [r, default_group] }
 
-      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |crs| [crs.kind, {:group => crs.group}] }
+      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.kind, { group: cr.group }] }
       Hash[before_crs + crs + after_crs]
     end
 
@@ -213,8 +213,8 @@ module Krane
     end
 
     def deploy_has_priority_resources?(resources)
-      resources.any? do |r| 
-        next unless cr = predeploy_sequence[r.type]
+      resources.any? do |r|
+        next unless (cr = predeploy_sequence[r.type])
         !cr[:group] || cr[:group] == r.group
       end
     end

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -230,7 +230,7 @@ module Krane
 
     def group
       grouping, *version = @definition.dig("apiVersion").split("/")
-      version.empty? ? grouping : "core"
+      version.empty? ? "core" : grouping
     end
 
     def kubectl_resource_type

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -230,8 +230,8 @@ module Krane
 
     def group
       grouping, *version = @definition.dig("apiVersion").split("/")
-      version.length > 0 ? grouping : "core"
-    end 
+      version.empty? ? grouping : "core"
+    end
 
     def kubectl_resource_type
       type

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -228,6 +228,11 @@ module Krane
       @type || self.class.kind
     end
 
+    def group
+      grouping, *version = @definition.dig("apiVersion").split("/")
+      version.length > 0 ? grouping : "core"
+    end 
+
     def kubectl_resource_type
       type
     end

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -46,6 +46,10 @@ module Krane
       @definition.dig("spec", "names", "kind")
     end
 
+    def group
+      @definition.dig("spec", "group")
+    end
+
     def prunable?
       prunable = krane_annotation_value("prunable")
       prunable == "true"

--- a/test/fixtures/crd/service_cr.yml
+++ b/test/fixtures/crd/service_cr.yml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: services.stable.example.io
+  labels:
+    app: krane
+spec:
+  group: stable.example.io
+  names:
+    kind: Service
+    plural: services
+    singular: service
+  scope: Namespaced
+  version: v1

--- a/test/fixtures/crd/web.yml
+++ b/test/fixtures/crd/web.yml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  labels:
+    name: web
+    app: hello-cloud
+spec:
+  rules:
+  - host: hello-cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: web
+          servicePort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    name: web
+    app: hello-cloud
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: http
+  selector:
+    name: web
+    app: hello-cloud
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  annotations:
+    shipit.shopify.io/restart: "true"
+  labels:
+    name: web
+    app: hello-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud
+  progressDeadlineSeconds: 60
+  template:
+    metadata:
+      labels:
+        name: web
+        app: hello-cloud
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+      - name: sidecar
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -382,6 +382,19 @@ class SerialDeployTest < Krane::IntegrationTest
     ])
   end
 
+  def test_cr_success_with_service
+    filepath = "#{fixture_path('crd')}/service_cr.yml"
+    out, err, st = build_kubectl.run("create", "-f", filepath, log_failure: true, use_namespace: false)
+    assert(st.success?, "Failed to create CRD: #{out}\n#{err}")
+
+    assert_deploy_success(deploy_fixtures("crd", subset: %w(web.yml)))
+
+    refute_logs_match(%r{Predeploying priority resources})
+    assert_logs_match_all([%r{Phase 3: Deploying all resources}])
+  ensure
+    build_kubectl.run("delete", "-f", filepath, use_namespace: false, log_failure: false)
+  end
+
   def test_cr_success_with_default_rollout_conditions_deprecated_annotation
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(with_default_conditions_deprecated.yml)))
     success_conditions = {

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -389,8 +389,8 @@ class SerialDeployTest < Krane::IntegrationTest
 
     assert_deploy_success(deploy_fixtures("crd", subset: %w(web.yml)))
 
-    refute_logs_match(%r{Predeploying priority resources})
-    assert_logs_match_all([%r{Phase 3: Deploying all resources}])
+    refute_logs_match(/Predeploying priority resources/)
+    assert_logs_match_all([/Phase 3: Deploying all resources/])
   ensure
     build_kubectl.run("delete", "-f", filepath, use_namespace: false, log_failure: false)
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
closes https://github.com/Shopify/krane/issues/728
Creating a custom resource def that has the same `kind` type as a core type can cause deploying a core type to be considered a priority resource. 

**How is this accomplished?**
We should also consider `group` when deciding if resources are crd's. The predeploy_sequence array list was converted to a hash keyed by kind

**What could go wrong?**
Could this mess up priority decision logic for other resources? Tests don't seem to be broken for crs so 👍 sign
