### PR TITLE
Stop core service from being deployed a priority resource

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -228,6 +228,11 @@ module Krane
       @type || self.class.kind
     end
 
+    def group
+      grouping, version = @definition.dig("apiVersion").split("/")
+      version ? grouping : "core"
+    end
+
     def kubectl_resource_type
       type
     end

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -46,6 +46,10 @@ module Krane
       @definition.dig("spec", "names", "kind")
     end
 
+    def group
+      @definition.dig("spec", "group")
+    end
+
     def prunable?
       prunable = krane_annotation_value("prunable")
       prunable == "true"

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -46,8 +46,11 @@ module Krane
         bare_pods.first.stream_logs = true
       end
 
-      predeploy_sequence.each do |resource_type|
-        matching_resources = resource_list.select { |r| r.type == resource_type }
+      predeploy_sequence.each do |resource_type, attributes|
+        matching_resources = resource_list.select do |r|
+          r.type == resource_type &&
+          (!attributes[:group] || r.group == attributes[:group])
+        end
         StatsD.client.gauge('priority_resources.count', matching_resources.size, tags: statsd_tags)
 
         next if matching_resources.empty?

--- a/test/fixtures/crd/service_cr.yml
+++ b/test/fixtures/crd/service_cr.yml
@@ -1,0 +1,14 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: services.stable.example.io
+  labels:
+    app: krane
+spec:
+  group: stable.example.io
+  names:
+    kind: Service
+    plural: services
+    singular: service
+  scope: Namespaced
+  version: v1

--- a/test/fixtures/crd/web.yml
+++ b/test/fixtures/crd/web.yml
@@ -1,0 +1,67 @@
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: web
+  labels:
+    name: web
+    app: hello-cloud
+spec:
+  rules:
+  - host: hello-cloud.example.com
+    http:
+      paths:
+      - backend:
+          serviceName: web
+          servicePort: 80
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: web
+  labels:
+    name: web
+    app: hello-cloud
+spec:
+  ports:
+  - port: 80
+    name: http
+    targetPort: http
+  selector:
+    name: web
+    app: hello-cloud
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  annotations:
+    shipit.shopify.io/restart: "true"
+  labels:
+    name: web
+    app: hello-cloud
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      name: web
+      app: hello-cloud
+  progressDeadlineSeconds: 60
+  template:
+    metadata:
+      labels:
+        name: web
+        app: hello-cloud
+    spec:
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        ports:
+        - containerPort: 80
+          name: http
+        env:
+      - name: sidecar
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]

--- a/test/helpers/mock_resource.rb
+++ b/test/helpers/mock_resource.rb
@@ -21,6 +21,10 @@ MockResource = Struct.new(:id, :hits_to_complete, :status) do
   end
   alias_method :kubectl_resource_type, :type
 
+  def group
+    "core"
+  end
+
   def pretty_timeout_type
   end
 

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -382,6 +382,19 @@ class SerialDeployTest < Krane::IntegrationTest
     ])
   end
 
+  def test_cr_success_with_service
+    filepath = "#{fixture_path('crd')}/service_cr.yml"
+    out, err, st = build_kubectl.run("create", "-f", filepath, log_failure: true, use_namespace: false)
+    assert(st.success?, "Failed to create CRD: #{out}\n#{err}")
+
+    assert_deploy_success(deploy_fixtures("crd", subset: %w(web.yml)))
+
+    refute_logs_match(/Predeploying priority resources/)
+    assert_logs_match_all([/Phase 3: Deploying all resources/])
+  ensure
+    build_kubectl.run("delete", "-f", filepath, use_namespace: false, log_failure: false)
+  end
+
   def test_cr_success_with_default_rollout_conditions_deprecated_annotation
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(with_default_conditions_deprecated.yml)))
     success_conditions = {

--- a/test/unit/krane/resource_deployer_test.rb
+++ b/test/unit/krane/resource_deployer_test.rb
@@ -71,7 +71,7 @@ class ResourceDeployerTest < Krane::TestCase
     # are deployed. See test_predeploy_priority_resources_respects_empty_pre_deploy_list
     # for counter example
     Krane::ResourceWatcher.expects(:new).returns(watcher)
-    priority_list = [kind]
+    priority_list = { kind => { group: "core" } }
     resource_deployer.predeploy_priority_resources([resource], priority_list)
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
closes https://github.com/Shopify/krane/issues/728
Creating a custom resource def that has the same `kind` type as a core type can cause deploying a core type to be considered a priority resource. 

**How is this accomplished?**
We should also consider `group` when deciding if resources are crd's. The predeploy_sequence array list was converted to a hash keyed by kind

**What could go wrong?**
Could this mess up priority decision logic for other resources? Tests don't seem to be broken for crs so 👍 sign