### PR TITLE
Update minikube cask location in dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ up:
   - ruby: 2.5.7 # Matches gemspec
   - bundler
   - homebrew:
-    - Caskroom/cask/minikube
+    - homebrew/cask/minikube
   - custom:
       name: Install the minikube fork of driver-hyperkit
       met?: command -v docker-machine-driver-hyperkit


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Had errors running `dev up`:

> Error: caskroom/cask was moved. Tap homebrew/cask instead.

**How is this accomplished?**

Updating the cask location.

**What could go wrong?**

Not much: it's only a dev.yml. I was able to dev up after this change, please give it a try yourselves.
