### PR TITLE
Allow specifying a kubeconfig per task in the internal API

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,6 +7,7 @@ Rake::TestTask.new(:integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/integration/**/*_test.rb']
+  t.warning = false
 end
 
 desc("Run integration tests that CANNOT be run in parallel")
@@ -14,6 +15,7 @@ Rake::TestTask.new(:serial_integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/integration-serial/**/*_test.rb']
+  t.warning = false
 end
 
 desc("Run unit tests")
@@ -21,6 +23,7 @@ Rake::TestTask.new(:unit_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/unit/**/*_test.rb']
+  t.warning = false
 end
 
 desc("Run cli tests")
@@ -28,6 +31,7 @@ Rake::TestTask.new(:cli_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/exe/**/*_test.rb']
+  t.warning = false
 end
 
 desc("Run all tests")

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,6 @@ Rake::TestTask.new(:integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/integration/**/*_test.rb']
-  t.warning = false
 end
 
 desc("Run integration tests that CANNOT be run in parallel")
@@ -15,7 +14,6 @@ Rake::TestTask.new(:serial_integration_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/integration-serial/**/*_test.rb']
-  t.warning = false
 end
 
 desc("Run unit tests")
@@ -23,7 +21,6 @@ Rake::TestTask.new(:unit_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/unit/**/*_test.rb']
-  t.warning = false
 end
 
 desc("Run cli tests")
@@ -31,7 +28,6 @@ Rake::TestTask.new(:cli_test) do |t|
   t.libs << "test"
   t.libs << "lib"
   t.test_files = FileList['test/exe/**/*_test.rb']
-  t.warning = false
 end
 
 desc("Run all tests")

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -101,10 +101,10 @@ module Krane
     # @param render_erb [Boolean] Enable ERB rendering
     def initialize(namespace:, context:, current_sha: nil, logger: nil, kubectl_instance: nil, bindings: {},
       global_timeout: nil, selector: nil, filenames: [], protected_namespaces: nil,
-      render_erb: false)
+      render_erb: false, kubeconfig: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
       @template_sets = TemplateSets.from_dirs_and_files(paths: filenames, logger: @logger, render_erb: render_erb)
-      @task_config = Krane::TaskConfig.new(context, namespace, @logger)
+      @task_config = Krane::TaskConfig.new(context, namespace, @logger, kubeconfig)
       @bindings = bindings
       @namespace = namespace
       @namespace_tags = []
@@ -191,7 +191,7 @@ module Krane
     end
 
     def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new
+      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
 
     def cluster_resource_discoverer

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -87,7 +87,7 @@ module Krane
 
     attr_reader :task_config
 
-    delegate :kubeclient_builder, to: :@task_config
+    delegate :kubeclient_builder, to: :task_config
 
     # Initializes the deploy task
     #

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -85,6 +85,8 @@ module Krane
       kubectl.server_version
     end
 
+    attr_reader :task_config
+
     # Initializes the deploy task
     #
     # @param namespace [String] Kubernetes namespace (*required*)

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -87,6 +87,8 @@ module Krane
 
     attr_reader :task_config
 
+    delegate :kubeclient_builder, to: :@task_config
+
     # Initializes the deploy task
     #
     # @param namespace [String] Kubernetes namespace (*required*)
@@ -190,10 +192,6 @@ module Krane
       @resource_deployer ||= Krane::ResourceDeployer.new(task_config: @task_config,
         prune_whitelist: prune_whitelist, global_timeout: @global_timeout,
         selector: @selector, statsd_tags: statsd_tags, current_sha: @current_sha)
-    end
-
-    def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
 
     def cluster_resource_discoverer

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -25,7 +25,7 @@ module Krane
   class GlobalDeployTask
     extend Krane::StatsD::MeasureMethods
     include TemplateReporting
-    delegate :context, :logger, :global_kinds, to: :@task_config
+    delegate :context, :logger, :global_kinds, :kubeclient_builder, to: :@task_config
     attr_reader :task_config
 
     # Initializes the deploy task
@@ -188,10 +188,6 @@ module Krane
 
     def kubectl
       @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true)
-    end
-
-    def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
 
     def prune_whitelist

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -26,6 +26,7 @@ module Krane
     extend Krane::StatsD::MeasureMethods
     include TemplateReporting
     delegate :context, :logger, :global_kinds, to: :@task_config
+    attr_reader :task_config
 
     # Initializes the deploy task
     #
@@ -33,10 +34,10 @@ module Krane
     # @param global_timeout [Integer] Timeout in seconds
     # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector (*required*)
     # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
-    def initialize(context:, global_timeout: nil, selector: nil, filenames: [], logger: nil)
+    def initialize(context:, global_timeout: nil, selector: nil, filenames: [], logger: nil, kubeconfig: nil)
       template_paths = filenames.map { |path| File.expand_path(path) }
 
-      @task_config = TaskConfig.new(context, nil, logger)
+      @task_config = TaskConfig.new(context, nil, logger, kubeconfig)
       @template_sets = TemplateSets.from_dirs_and_files(paths: template_paths,
         logger: @task_config.logger, render_erb: false)
       @global_timeout = global_timeout
@@ -190,7 +191,7 @@ module Krane
     end
 
     def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new
+      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
 
     def prune_whitelist

--- a/lib/krane/kubeclient_builder.rb
+++ b/lib/krane/kubeclient_builder.rb
@@ -10,8 +10,8 @@ module Krane
       end
     end
 
-    def initialize(kubeconfig: ENV["KUBECONFIG"])
-      files = kubeconfig || "#{Dir.home}/.kube/config"
+    def initialize(kubeconfig: nil)
+      files = kubeconfig || ENV["KUBECONFIG"] || "#{Dir.home}/.kube/config"
       # Split the list by colon for Linux and Mac, and semicolon for Windows.
       @kubeconfig_files = files.split(/[:;]/).map!(&:strip).reject(&:empty?)
     end

--- a/lib/krane/kubeclient_builder.rb
+++ b/lib/krane/kubeclient_builder.rb
@@ -10,6 +10,8 @@ module Krane
       end
     end
 
+    attr_reader :kubeconfig_files
+
     def initialize(kubeconfig: nil)
       files = kubeconfig || ENV["KUBECONFIG"] || "#{Dir.home}/.kube/config"
       # Split the list by colon for Linux and Mac, and semicolon for Windows.

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -14,7 +14,7 @@ module Krane
 
     class ResourceNotFoundError < StandardError; end
 
-    delegate :namespace, :context, :logger, to: :@task_config
+    delegate :namespace, :context, :logger, :kubeconfig, to: :@task_config
 
     def initialize(task_config:, log_failure_by_default:, default_timeout: DEFAULT_TIMEOUT,
       output_is_sensitive_default: false)
@@ -34,7 +34,8 @@ module Krane
 
       (1..attempts).to_a.each do |current_attempt|
         logger.debug("Running command (attempt #{current_attempt}): #{cmd.join(' ')}")
-        out, err, st = Open3.capture3(*cmd)
+        env = { 'KUBECONFIG' => kubeconfig }
+        out, err, st = Open3.capture3(env, *cmd)
 
         # https://github.com/Shopify/krane/issues/395
         unless out.valid_encoding?

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -24,6 +24,8 @@ module Krane
 
     attr_reader :task_config
 
+    delegate :kubeclient_builder, to: :@task_config
+
     # Initializes the restart task
     #
     # @param context [String] Kubernetes context / cluster (*required*)
@@ -221,10 +223,6 @@ module Krane
 
     def v1beta1_kubeclient
       @v1beta1_kubeclient ||= kubeclient_builder.build_v1beta1_kubeclient(@context)
-    end
-
-    def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
   end
 end

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -24,7 +24,7 @@ module Krane
 
     attr_reader :task_config
 
-    delegate :kubeclient_builder, to: :@task_config
+    delegate :kubeclient_builder, to: :task_config
 
     # Initializes the restart task
     #

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -22,15 +22,17 @@ module Krane
     HTTP_OK_RANGE = 200..299
     ANNOTATION = "shipit.shopify.io/restart"
 
+    attr_reader :task_config
+
     # Initializes the restart task
     #
     # @param context [String] Kubernetes context / cluster (*required*)
     # @param namespace [String] Kubernetes namespace (*required*)
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param global_timeout [Integer] Timeout in seconds
-    def initialize(context:, namespace:, logger: nil, global_timeout: nil)
+    def initialize(context:, namespace:, logger: nil, global_timeout: nil, kubeconfig: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
-      @task_config = Krane::TaskConfig.new(context, namespace, @logger)
+      @task_config = Krane::TaskConfig.new(context, namespace, @logger, kubeconfig)
       @context = context
       @namespace = namespace
       @global_timeout = global_timeout
@@ -222,7 +224,7 @@ module Krane
     end
 
     def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new
+      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
   end
 end

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -18,6 +18,8 @@ module Krane
 
     attr_reader :pod_name, :task_config
 
+    delegate :kubeclient_builder, to: :@task_config
+
     # Initializes the runner task
     #
     # @param namespace [String] Kubernetes namespace (*required*)
@@ -198,10 +200,6 @@ module Krane
 
     def kubeclient
       @kubeclient ||= kubeclient_builder.build_v1_kubeclient(@context)
-    end
-
-    def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
 
     def statsd_tags(status)

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -18,7 +18,7 @@ module Krane
 
     attr_reader :pod_name, :task_config
 
-    delegate :kubeclient_builder, to: :@task_config
+    delegate :kubeclient_builder, to: :task_config
 
     # Initializes the runner task
     #

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -16,7 +16,7 @@ module Krane
   class RunnerTask
     class TaskTemplateMissingError < TaskConfigurationError; end
 
-    attr_reader :pod_name
+    attr_reader :pod_name, :task_config
 
     # Initializes the runner task
     #
@@ -24,9 +24,9 @@ module Krane
     # @param context [String] Kubernetes context / cluster (*required*)
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param global_timeout [Integer] Timeout in seconds
-    def initialize(namespace:, context:, logger: nil, global_timeout: nil)
+    def initialize(namespace:, context:, logger: nil, global_timeout: nil, kubeconfig: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
-      @task_config = Krane::TaskConfig.new(context, namespace, @logger)
+      @task_config = Krane::TaskConfig.new(context, namespace, @logger, kubeconfig)
       @namespace = namespace
       @context = context
       @global_timeout = global_timeout
@@ -201,7 +201,7 @@ module Krane
     end
 
     def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new
+      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: @task_config.kubeconfig)
     end
 
     def statsd_tags(status)

--- a/lib/krane/task_config.rb
+++ b/lib/krane/task_config.rb
@@ -19,5 +19,9 @@ module Krane
         cluster_resource_discoverer.fetch_resources(namespaced: false).map { |g| g["kind"] }
       end
     end
+
+    def kubeclient_builder
+      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: kubeconfig)
+    end
   end
 end

--- a/lib/krane/task_config.rb
+++ b/lib/krane/task_config.rb
@@ -4,12 +4,13 @@ require 'krane/cluster_resource_discovery'
 
 module Krane
   class TaskConfig
-    attr_reader :context, :namespace, :logger
+    attr_reader :context, :namespace, :logger, :kubeconfig
 
-    def initialize(context, namespace, logger = nil)
+    def initialize(context, namespace, logger = nil, kubeconfig = nil)
       @context = context
       @namespace = namespace
       @logger = logger || FormattedLogger.build(@namespace, @context)
+      @kubeconfig = kubeconfig || ENV['KUBECONFIG']
     end
 
     def global_kinds

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -91,7 +91,7 @@ module FixtureDeployHelper
   def deploy_dirs_without_profiling(dirs, wait: true, prune: true, bindings: {},
     sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil, selector: nil,
     protected_namespaces: nil, render_erb: false)
-    kubectl_instance ||= build_kubectl
+    kubectl_instance = build_kubectl
 
     deploy = Krane::DeployTask.new(
       namespace: @namespace,

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -9,54 +9,54 @@ module KubeclientHelper
   TEST_CONTEXT ||= "minikube"
 
   def kubeclient
-    @kubeclient ||= kubeclient_builder.build_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_v1_kubeclient(TEST_CONTEXT)
   end
 
   def v1beta1_kubeclient
-    @v1beta1_kubeclient ||= kubeclient_builder.build_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def policy_v1beta1_kubeclient
-    @policy_v1beta1_kubeclient ||= kubeclient_builder.build_policy_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_policy_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def apps_v1_kubeclient
-    @apps_v1_kubeclient ||= kubeclient_builder.build_apps_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_apps_v1_kubeclient(TEST_CONTEXT)
   end
 
   def batch_v1beta1_kubeclient
-    @batch_v1beta1_kubeclient ||= kubeclient_builder.build_batch_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_batch_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def batch_v1_kubeclient
-    @batch_v1_kubeclient ||= kubeclient_builder.build_batch_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_batch_v1_kubeclient(TEST_CONTEXT)
   end
 
   def apiextensions_v1beta1_kubeclient
-    @apiextensions_v1beta1_kubeclient ||= kubeclient_builder.build_apiextensions_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_apiextensions_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def autoscaling_v1_kubeclient
-    @autoscaling_v1_kubeclient ||= kubeclient_builder.build_autoscaling_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_autoscaling_v1_kubeclient(TEST_CONTEXT)
   end
 
   def rbac_v1_kubeclient
-    @rbac_v1_kubeclient ||= kubeclient_builder.build_rbac_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_rbac_v1_kubeclient(TEST_CONTEXT)
   end
 
   def networking_v1_kubeclient
-    @networking_v1_kubeclient ||= kubeclient_builder.build_networking_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_networking_v1_kubeclient(TEST_CONTEXT)
   end
 
   def storage_v1_kubeclient
-    @storage_v1_kubeclient ||= kubeclient_builder.build_storage_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_storage_v1_kubeclient(TEST_CONTEXT)
   end
 
   def scheduling_v1beta1_kubeclient
-    @scheduling_v1beta1_kubeclient ||= kubeclient_builder.build_scheduling_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_scheduling_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def kubeclient_builder
-    @kubeclient_builder ||= Krane::KubeclientBuilder.new
+    Krane::KubeclientBuilder.new
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -226,7 +226,7 @@ module Krane
     end
 
     def task_config(context: KubeclientHelper::TEST_CONTEXT, namespace: @namespace, logger: @logger)
-      @task_config ||= Krane::TaskConfig.new(context, namespace, logger)
+      Krane::TaskConfig.new(context, namespace, logger)
     end
 
     def krane_black_box(command, args = "", stdin: nil)

--- a/test/unit/krane/deploy_task_test.rb
+++ b/test/unit/krane/deploy_task_test.rb
@@ -23,4 +23,17 @@ class DeployTaskTest < Krane::TestCase
     assert_logs_match("Configuration invalid")
     assert_logs_match(/File (\S+) does not exist/)
   end
+
+  def test_kubeconfig_configured_correctly
+    task = Krane::DeployTask.new(
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      current_sha: "",
+      filenames: ["unknown"],
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
+  end
 end

--- a/test/unit/krane/deploy_task_test.rb
+++ b/test/unit/krane/deploy_task_test.rb
@@ -34,6 +34,5 @@ class DeployTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
-    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
   end
 end

--- a/test/unit/krane/deploy_task_test.rb
+++ b/test/unit/krane/deploy_task_test.rb
@@ -34,5 +34,6 @@ class DeployTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
   end
 end

--- a/test/unit/krane/global_deploy_task_test.rb
+++ b/test/unit/krane/global_deploy_task_test.rb
@@ -10,5 +10,6 @@ class GlobalDeployTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
   end
 end

--- a/test/unit/krane/global_deploy_task_test.rb
+++ b/test/unit/krane/global_deploy_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class GlobalDeployTaskTest < Krane::TestCase
+  def test_kubeconfig_configured_correctly
+    task = Krane::GlobalDeployTask.new(
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      filenames: ["unknown"],
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
+  end
+end

--- a/test/unit/krane/global_deploy_task_test.rb
+++ b/test/unit/krane/global_deploy_task_test.rb
@@ -10,6 +10,5 @@ class GlobalDeployTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
-    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
   end
 end

--- a/test/unit/krane/restart_task_test.rb
+++ b/test/unit/krane/restart_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RestartTaskTest < Krane::TestCase
+  def test_kubeconfig_configured_correctly
+    task = Krane::RestartTask.new(
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
+  end
+end

--- a/test/unit/krane/restart_task_test.rb
+++ b/test/unit/krane/restart_task_test.rb
@@ -10,6 +10,5 @@ class RestartTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
-    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
   end
 end

--- a/test/unit/krane/restart_task_test.rb
+++ b/test/unit/krane/restart_task_test.rb
@@ -10,5 +10,6 @@ class RestartTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
   end
 end

--- a/test/unit/krane/runner_task_test.rb
+++ b/test/unit/krane/runner_task_test.rb
@@ -10,6 +10,5 @@ class RunnerTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
-    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
   end
 end

--- a/test/unit/krane/runner_task_test.rb
+++ b/test/unit/krane/runner_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RunnerTaskTest < Krane::TestCase
+  def test_kubeconfig_configured_correctly
+    task = Krane::RunnerTask.new(
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    assert_equal(['/some/path.yml'], task.send(:kubeclient_builder).kubeconfig_files)
+  end
+end

--- a/test/unit/krane/runner_task_test.rb
+++ b/test/unit/krane/runner_task_test.rb
@@ -10,5 +10,6 @@ class RunnerTaskTest < Krane::TestCase
       kubeconfig: '/some/path.yml',
     )
     assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
   end
 end

--- a/test/unit/task_config_test.rb
+++ b/test/unit/task_config_test.rb
@@ -20,4 +20,15 @@ class TaskConfigTest < Krane::TestCase
     logger = Krane::FormattedLogger.build(nil, nil)
     assert_equal(task_config(logger: logger).logger, logger)
   end
+
+  def test_kubeconfig_configured_correctly
+    test_task_config = Krane::TaskConfig.new(
+      KubeclientHelper::TEST_CONTEXT,
+      "something",
+      logger,
+      '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', test_task_config.kubeconfig)
+    assert_equal(['/some/path.yml'], test_task_config.kubeclient_builder.kubeconfig_files)
+  end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Being primarily a cli tool, Krane currently relies on some global state in the environment - notable for this issue is the kubeconfig path. Deploying our main monolith at Shopify is a bit of a pathological case - we use Krane as a library, and deploy to multiple targets simultaneously using the internal API and threads.

Occasionally we are seeing some errors I believe are ultimately thread safety issues - e.g. apparent corruption of the kubeconfig as contexts are 'missing' (when we check the files, they are not), or base64 certificate data is invalid and un-decodeable. I have not been able to determine the precise cause here (e.g. fd leaks) as reproducing is very difficult, but would like to at least work around the symptom we're seeing by giving each deploy task its own kubeconfig instead of sharing one everywhere. This PR alters the internal API to allow this, while not changing the behaviour for cli users, and in doing so remove a little of this global state.

**How is this accomplished?**

Having the various `Task` classes take `kubeconfig` as a parameter, and ensuring that is passed through to `Kubectl` and `Kubeclient` instances. If `kubeconfig` is nil, the value of `KUBECONFIG` in the environment is used, preserving the current behaviour.

There is some prior art here. An explicit `--kubeconfig` option was added in #428 and then reverted in #468 as the cli flag did not support parsing multiple files. This approach overrides the `KUBECONFIG` envvar in the kubectl child process, which should avoid that issue.

I have removed a bunch of memoizing from the test suite as some tests currently rely on mutating global state, notably the multiple config file integration test. It's likely we can keep some of this optimisation by reworking these tests, but it could use someone with better knowledge of the test suite than me.

The various `Task` classes share a common set of options and setup, it might be worth refactoring these to share a base class and dedup some of the changes here, but I consider that out of scope for this PR.

**What could go wrong?**

As I noted above a change similar to this was attempted before and abandoned. I believe this approach of modifying the subprocess env avoids the previous issue, but maybe there's some other problem. I hope to test this branch by deploying our monolith to check for other issues, and that it actually resolves this issue we're seeing.

I have done some sanity 🎩 locally with minikube and fixtures.