### PR TITLE
Add hyperkit to the list of dependencies

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,6 +5,7 @@ up:
   - bundler
   - homebrew:
     - homebrew/cask/minikube
+    - hyperkit
   - custom:
       name: Install the minikube fork of driver-hyperkit
       met?: command -v docker-machine-driver-hyperkit


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

@rdji123 and I ran into this issue while we ran `dev up` on krane.

```
* minikube v1.12.2 on Darwin 10.15.4
┃┃   - KUBECONFIG=/Users/ruidan/.kube/config:/Users/ruidan/.kube/config.shopify.cloudplatform
┃┃ * Using the hyperkit driver based on user configuration
┃┃
┃┃ ! ‘hyperkit’ driver reported an issue: exec: “hyperkit”: executable file not found in $PATH
┃┃ * Suggestion: Run ‘brew install hyperkit’
┃┃ * Documentation: https://minikube.sigs.k8s.io/docs/reference/drivers/hyperkit/
┃┃
┃┃ X hyperkit does not appear to be installed
┃┣━━ (meet) minikube start --vm-driver=hyperkit failed ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃┃ This is a custom commmand that is defined in your project’s dev.yml.
┃┃ Any failures related to this command are the responsibility of your team.
┃┃
┃┃ If this fails a lot, you might want to check who added the command using git blame
┃┃ and ask them for help :)
┃┗━━ (meet) minikube start --vm-driver=hyperkit Failed! ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1.2s) ━━
┃ ✗ Minikube Cluster: failed!
┃ ✗ Error Reason:
┃ ✗   The command minikube start --vm-driver=hyperkit or the command test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q ‘Configured’) did not succeed
```

**How is this accomplished?**
...

**What could go wrong?**
...

cc @Shopify/pipeline 
