### PR TITLE
Refactor/attempts number and logs

### DIFF
--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -62,7 +62,7 @@ module Krane
         else
           logger.debug("Kubectl err: #{output_is_sensitive ? '<suppressed sensitive output>' : err}")
         end
-        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace, cmd: cmd[1] })
+        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace, cmd: cmd[1], max_attempt: attempts, current_attempt: current_attempt })
 
         break unless retriable_err?(err, retry_whitelist) && current_attempt < attempts
         sleep(retry_delay(current_attempt))

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -62,7 +62,8 @@ module Krane
         else
           logger.debug("Kubectl err: #{output_is_sensitive ? '<suppressed sensitive output>' : err}")
         end
-        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace, cmd: cmd[1], max_attempt: attempts, current_attempt: current_attempt })
+        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace, cmd: cmd[1],
+                                                            max_attempt: attempts, current_attempt: current_attempt })
 
         break unless retriable_err?(err, retry_whitelist) && current_attempt < attempts
         sleep(retry_delay(current_attempt))

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -79,7 +79,7 @@ module Krane
     def version_info
       @version_info ||=
         begin
-          response, _, status = run("version", use_namespace: false, log_failure: true)
+          response, _, status = run("version", use_namespace: false, log_failure: true, attempts: 2)
           raise KubectlError, "Could not retrieve kubectl version info" unless status.success?
           extract_version_info_from_kubectl_response(response)
         end

--- a/lib/krane/task_config_validator.rb
+++ b/lib/krane/task_config_validator.rb
@@ -71,7 +71,7 @@ module Krane
       end
 
       _, err, st = @kubectl.run("get", "namespace", "-o", "name", namespace,
-        use_namespace: false, log_failure: false, attempts: 2)
+        use_namespace: false, log_failure: false, attempts: 3)
 
       unless st.success?
         @errors << if err.match("Error from server [(]NotFound[)]: namespace")

--- a/lib/krane/task_config_validator.rb
+++ b/lib/krane/task_config_validator.rb
@@ -45,7 +45,7 @@ module Krane
       end
 
       _, err, st = @kubectl.run("config", "get-contexts", context, "-o", "name",
-        use_namespace: false, use_context: false, log_failure: false)
+        use_namespace: false, use_context: false, log_failure: false, attempts: 2)
 
       unless st.success?
         @errors << if err.match("error: context #{context} not found")
@@ -58,7 +58,7 @@ module Krane
 
     def validate_context_reachable
       _, err, st = @kubectl.run("get", "namespaces", "-o", "name",
-        use_namespace: false, log_failure: false)
+        use_namespace: false, log_failure: false, attempts: 2)
 
       unless st.success?
         @errors << "Something went wrong connecting to #{context}. #{err} "
@@ -71,7 +71,7 @@ module Krane
       end
 
       _, err, st = @kubectl.run("get", "namespace", "-o", "name", namespace,
-        use_namespace: false, log_failure: false)
+        use_namespace: false, log_failure: false, attempts: 2)
 
       unless st.success?
         @errors << if err.match("Error from server [(]NotFound[)]: namespace")

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 
 class EjsonSecretProvisionerTest < Krane::TestCase
   def test_resources_based_on_ejson_file_existence
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
+
     assert_empty(build_provisioner(fixture_path('hello-cloud')).resources)
     refute_empty(build_provisioner(fixture_path('ejson-cloud')).resources)
   end
@@ -18,11 +19,10 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def test_resource_is_built_correctly
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
     resources = build_provisioner(fixture_path('ejson-cloud')).resources
     refute_empty(resources)
-
     secret = resources.find { |s| s.name == 'monitoring-token' }
     refute_nil(secret, "Expected secret not found")
     assert_equal(secret.class, Krane::Secret)
@@ -72,7 +72,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
     Open3.expects(:capture3).with(regexp_matches(/ejson decrypt/))
       .returns([valid_response, "Permissions warning!", stub(success?: true)])
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request
 
     resources = build_provisioner(fixture_path('ejson-cloud')).resources
@@ -110,7 +110,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def test_proactively_validates_resulting_resources_and_raises_without_logging
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request
     Krane::Secret.any_instance.expects(:validation_failed?).returns(true)
     msg = "Generation of Kubernetes secrets from ejson failed: Resulting resource Secret/catphotoscom failed validation"
@@ -121,7 +121,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def test_run_with_selector_does_not_raise_exception
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
     provisioner = build_provisioner(
       fixture_path('ejson-cloud'),
@@ -132,23 +132,24 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
   private
 
-  def stub_server_dry_run_validation_request
+  def stub_server_dry_run_validation_request(attempts: 3)
     stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
       resp: dummy_secret_hash, json: false,
       kwargs: {
         log_failure: false,
         output_is_sensitive: true,
         retry_whitelist: [:client_timeout, :empty],
-        attempts: 3,
+        attempts: attempts,
       })
   end
 
-  def stub_server_dry_run_version_request
+  def stub_server_dry_run_version_request(attempts: 3)
     stub_kubectl_response("version",
       resp: dummy_version, json: false,
         kwargs: {
           use_namespace: false,
           log_failure: true,
+          attempts: attempts,
         })
   end
 

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -143,7 +143,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
       })
   end
 
-  def stub_server_dry_run_version_request(attempts: 3)
+  def stub_server_dry_run_version_request(attempts: 1)
     stub_kubectl_response("version",
       resp: dummy_version, json: false,
         kwargs: {

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -173,7 +173,7 @@ class KubectlTest < Krane::TestCase
     stub_open3(
       %W(kubectl version --context=testc --request-timeout=#{timeout}),
       resp: '', err: 'bad', success: false
-    )
+    ).times(2)
     assert_raises_message(Krane::KubectlError, "Could not retrieve kubectl version info") do
       build_kubectl.version_info
     end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
This change allows for some context deadline errors to be retried addressing issue
https://github.com/Shopify/shipit/issues/1227
**How is this accomplished?**
![image](https://user-images.githubusercontent.com/36777675/92933669-879da400-f414-11ea-87f4-dd0bbb2d1677.png)
We noticed that many of the context deadline errors came from cmd:get, we've 
updated the number of attempts on the following functions:
- validate_context_exists_in_kubeconfig (cmd: config, get-context)
- version_info (cmd: version)
- validate_context_reachable (cmd: get, namespace)
- validate_namespace_exists (cmd: get, namespace)

**Before you deploy**

- [ ] I tophatted or tested this change.
- [x] This PR is safe to rollback.
