### PR TITLE
Refactor/update attempts kubectl apply

### DIFF
--- a/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -264,7 +264,7 @@ Style/MethodCallWithArgsParentheses:
   - raise
   - puts
   Exclude:
-  - Gemfile
+  - '**/Gemfile'
 
 Style/MethodDefParentheses:
   EnforcedStyle: require_parentheses
@@ -675,7 +675,7 @@ Style/LineEndConcatenation:
 Style/MethodCallWithoutArgsParentheses:
   Enabled: true
 
-Style/MethodMissingSuper:
+Lint/MissingSuper:
   Enabled: true
 
 Style/MissingRespondToMissing:
@@ -965,7 +965,7 @@ Lint/UselessAccessModifier:
 Lint/UselessAssignment:
   Enabled: true
 
-Lint/UselessComparison:
+Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
 Lint/UselessElseWithoutRescue:

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -56,6 +56,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("byebug")
   spec.add_development_dependency("ruby-prof")
   spec.add_development_dependency("ruby-prof-flamegraph")
-  spec.add_development_dependency("rubocop", "~> 0.88.0")
+  spec.add_development_dependency("rubocop", "~> 0.89.1")
   spec.add_development_dependency("codecov")
 end

--- a/lib/krane/kubeclient_builder.rb
+++ b/lib/krane/kubeclient_builder.rb
@@ -10,8 +10,10 @@ module Krane
       end
     end
 
-    def initialize(kubeconfig: ENV["KUBECONFIG"])
-      files = kubeconfig || "#{Dir.home}/.kube/config"
+    attr_reader :kubeconfig_files
+
+    def initialize(kubeconfig: nil)
+      files = kubeconfig || ENV["KUBECONFIG"] || "#{Dir.home}/.kube/config"
       # Split the list by colon for Linux and Mac, and semicolon for Windows.
       @kubeconfig_files = files.split(/[:;]/).map!(&:strip).reject(&:empty?)
     end

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -14,7 +14,7 @@ module Krane
 
     class ResourceNotFoundError < StandardError; end
 
-    delegate :namespace, :context, :logger, to: :@task_config
+    delegate :namespace, :context, :logger, :kubeconfig, to: :@task_config
 
     def initialize(task_config:, log_failure_by_default:, default_timeout: DEFAULT_TIMEOUT,
       output_is_sensitive_default: false)
@@ -34,7 +34,8 @@ module Krane
 
       (1..attempts).to_a.each do |current_attempt|
         logger.debug("Running command (attempt #{current_attempt}): #{cmd.join(' ')}")
-        out, err, st = Open3.capture3(*cmd)
+        env = { 'KUBECONFIG' => kubeconfig }
+        out, err, st = Open3.capture3(env, *cmd)
 
         # https://github.com/Shopify/krane/issues/395
         unless out.valid_encoding?

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -63,7 +63,8 @@ module Krane
         else
           logger.debug("Kubectl err: #{output_is_sensitive ? '<suppressed sensitive output>' : err}")
         end
-        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace, cmd: cmd[1] })
+        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace, cmd: cmd[1],
+                                                            max_attempt: attempts, current_attempt: current_attempt })
 
         break unless retriable_err?(err, retry_whitelist) && current_attempt < attempts
         sleep(retry_delay(current_attempt))
@@ -80,7 +81,7 @@ module Krane
     def version_info
       @version_info ||=
         begin
-          response, _, status = run("version", use_namespace: false, log_failure: true)
+          response, _, status = run("version", use_namespace: false, log_failure: true, attempts: 2)
           raise KubectlError, "Could not retrieve kubectl version info" unless status.success?
           extract_version_info_from_kubectl_response(response)
         end

--- a/lib/krane/kubernetes_resource/persistent_volume_claim.rb
+++ b/lib/krane/kubernetes_resource/persistent_volume_claim.rb
@@ -63,6 +63,7 @@ module Krane
       attr_reader :name
 
       def initialize(definition)
+        super(definition: definition, namespace: nil, context: nil, logger: nil)
         @definition = definition
         @name = definition.dig("metadata", "name").to_s
       end

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -152,6 +152,7 @@ module Krane
 
         output_is_sensitive = resources.any?(&:sensitive_template_content?)
         global_mode = resources.all?(&:global?)
+        
         out, err, st = kubectl.run(*command, log_failure: false, output_is_sensitive: output_is_sensitive,
           attempts: 2, use_namespace: !global_mode)
 

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -152,7 +152,6 @@ module Krane
 
         output_is_sensitive = resources.any?(&:sensitive_template_content?)
         global_mode = resources.all?(&:global?)
-        
         out, err, st = kubectl.run(*command, log_failure: false, output_is_sensitive: output_is_sensitive,
           attempts: 2, use_namespace: !global_mode)
 

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -153,7 +153,7 @@ module Krane
         output_is_sensitive = resources.any?(&:sensitive_template_content?)
         global_mode = resources.all?(&:global?)
         out, err, st = kubectl.run(*command, log_failure: false, output_is_sensitive: output_is_sensitive,
-          use_namespace: !global_mode)
+          attempts: 2, use_namespace: !global_mode)
 
         if st.success?
           log_pruning(out) if prune

--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -22,15 +22,19 @@ module Krane
     HTTP_OK_RANGE = 200..299
     ANNOTATION = "shipit.shopify.io/restart"
 
+    attr_reader :task_config
+
+    delegate :kubeclient_builder, to: :task_config
+
     # Initializes the restart task
     #
     # @param context [String] Kubernetes context / cluster (*required*)
     # @param namespace [String] Kubernetes namespace (*required*)
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param global_timeout [Integer] Timeout in seconds
-    def initialize(context:, namespace:, logger: nil, global_timeout: nil)
+    def initialize(context:, namespace:, logger: nil, global_timeout: nil, kubeconfig: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
-      @task_config = Krane::TaskConfig.new(context, namespace, @logger)
+      @task_config = Krane::TaskConfig.new(context, namespace, @logger, kubeconfig)
       @context = context
       @namespace = namespace
       @global_timeout = global_timeout
@@ -219,10 +223,6 @@ module Krane
 
     def v1beta1_kubeclient
       @v1beta1_kubeclient ||= kubeclient_builder.build_v1beta1_kubeclient(@context)
-    end
-
-    def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new
     end
   end
 end

--- a/lib/krane/runner_task.rb
+++ b/lib/krane/runner_task.rb
@@ -16,7 +16,9 @@ module Krane
   class RunnerTask
     class TaskTemplateMissingError < TaskConfigurationError; end
 
-    attr_reader :pod_name
+    attr_reader :pod_name, :task_config
+
+    delegate :kubeclient_builder, to: :task_config
 
     # Initializes the runner task
     #
@@ -24,9 +26,9 @@ module Krane
     # @param context [String] Kubernetes context / cluster (*required*)
     # @param logger [Object] Logger object (defaults to an instance of Krane::FormattedLogger)
     # @param global_timeout [Integer] Timeout in seconds
-    def initialize(namespace:, context:, logger: nil, global_timeout: nil)
+    def initialize(namespace:, context:, logger: nil, global_timeout: nil, kubeconfig: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
-      @task_config = Krane::TaskConfig.new(context, namespace, @logger)
+      @task_config = Krane::TaskConfig.new(context, namespace, @logger, kubeconfig)
       @namespace = namespace
       @context = context
       @global_timeout = global_timeout
@@ -198,10 +200,6 @@ module Krane
 
     def kubeclient
       @kubeclient ||= kubeclient_builder.build_v1_kubeclient(@context)
-    end
-
-    def kubeclient_builder
-      @kubeclient_builder ||= KubeclientBuilder.new
     end
 
     def statsd_tags(status)

--- a/lib/krane/task_config.rb
+++ b/lib/krane/task_config.rb
@@ -4,12 +4,13 @@ require 'krane/cluster_resource_discovery'
 
 module Krane
   class TaskConfig
-    attr_reader :context, :namespace, :logger
+    attr_reader :context, :namespace, :logger, :kubeconfig
 
-    def initialize(context, namespace, logger = nil)
+    def initialize(context, namespace, logger = nil, kubeconfig = nil)
       @context = context
       @namespace = namespace
       @logger = logger || FormattedLogger.build(@namespace, @context)
+      @kubeconfig = kubeconfig || ENV['KUBECONFIG']
     end
 
     def global_kinds
@@ -17,6 +18,10 @@ module Krane
         cluster_resource_discoverer = ClusterResourceDiscovery.new(task_config: self)
         cluster_resource_discoverer.fetch_resources(namespaced: false).map { |g| g["kind"] }
       end
+    end
+
+    def kubeclient_builder
+      @kubeclient_builder ||= KubeclientBuilder.new(kubeconfig: kubeconfig)
     end
   end
 end

--- a/lib/krane/task_config_validator.rb
+++ b/lib/krane/task_config_validator.rb
@@ -45,7 +45,7 @@ module Krane
       end
 
       _, err, st = @kubectl.run("config", "get-contexts", context, "-o", "name",
-        use_namespace: false, use_context: false, log_failure: false)
+        use_namespace: false, use_context: false, log_failure: false, attempts: 2)
 
       unless st.success?
         @errors << if err.match("error: context #{context} not found")
@@ -58,7 +58,7 @@ module Krane
 
     def validate_context_reachable
       _, err, st = @kubectl.run("get", "namespaces", "-o", "name",
-        use_namespace: false, log_failure: false)
+        use_namespace: false, log_failure: false, attempts: 2)
 
       unless st.success?
         @errors << "Something went wrong connecting to #{context}. #{err} "
@@ -71,7 +71,7 @@ module Krane
       end
 
       _, err, st = @kubectl.run("get", "namespace", "-o", "name", namespace,
-        use_namespace: false, log_failure: false)
+        use_namespace: false, log_failure: false, attempts: 3)
 
       unless st.success?
         @errors << if err.match("Error from server [(]NotFound[)]: namespace")

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -91,7 +91,7 @@ module FixtureDeployHelper
   def deploy_dirs_without_profiling(dirs, wait: true, prune: true, bindings: {},
     sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil, selector: nil,
     protected_namespaces: nil, render_erb: false)
-    kubectl_instance ||= build_kubectl
+    kubectl_instance = build_kubectl
 
     deploy = Krane::DeployTask.new(
       namespace: @namespace,

--- a/test/helpers/fixture_sets/cronjobs.rb
+++ b/test/helpers/fixture_sets/cronjobs.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# rubocop:disable Lint/MissingSuper
+
 module FixtureSetAssertions
   class CronJobs < FixtureSet
     def initialize(namespace)

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# rubocop:disable Lint/MissingSuper
+
 module FixtureSetAssertions
   class EjsonCloud < FixtureSet
     def initialize(namespace)

--- a/test/helpers/fixture_sets/hello_cloud.rb
+++ b/test/helpers/fixture_sets/hello_cloud.rb
@@ -1,4 +1,6 @@
 # frozen_string_literal: true
+# rubocop:disable Lint/MissingSuper
+
 module FixtureSetAssertions
   class HelloCloud < FixtureSet
     def initialize(namespace)

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -9,54 +9,54 @@ module KubeclientHelper
   TEST_CONTEXT ||= "minikube"
 
   def kubeclient
-    @kubeclient ||= kubeclient_builder.build_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_v1_kubeclient(TEST_CONTEXT)
   end
 
   def v1beta1_kubeclient
-    @v1beta1_kubeclient ||= kubeclient_builder.build_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def policy_v1beta1_kubeclient
-    @policy_v1beta1_kubeclient ||= kubeclient_builder.build_policy_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_policy_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def apps_v1_kubeclient
-    @apps_v1_kubeclient ||= kubeclient_builder.build_apps_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_apps_v1_kubeclient(TEST_CONTEXT)
   end
 
   def batch_v1beta1_kubeclient
-    @batch_v1beta1_kubeclient ||= kubeclient_builder.build_batch_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_batch_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def batch_v1_kubeclient
-    @batch_v1_kubeclient ||= kubeclient_builder.build_batch_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_batch_v1_kubeclient(TEST_CONTEXT)
   end
 
   def apiextensions_v1beta1_kubeclient
-    @apiextensions_v1beta1_kubeclient ||= kubeclient_builder.build_apiextensions_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_apiextensions_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def autoscaling_v1_kubeclient
-    @autoscaling_v1_kubeclient ||= kubeclient_builder.build_autoscaling_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_autoscaling_v1_kubeclient(TEST_CONTEXT)
   end
 
   def rbac_v1_kubeclient
-    @rbac_v1_kubeclient ||= kubeclient_builder.build_rbac_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_rbac_v1_kubeclient(TEST_CONTEXT)
   end
 
   def networking_v1_kubeclient
-    @networking_v1_kubeclient ||= kubeclient_builder.build_networking_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_networking_v1_kubeclient(TEST_CONTEXT)
   end
 
   def storage_v1_kubeclient
-    @storage_v1_kubeclient ||= kubeclient_builder.build_storage_v1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_storage_v1_kubeclient(TEST_CONTEXT)
   end
 
   def scheduling_v1beta1_kubeclient
-    @scheduling_v1beta1_kubeclient ||= kubeclient_builder.build_scheduling_v1beta1_kubeclient(TEST_CONTEXT)
+    kubeclient_builder.build_scheduling_v1beta1_kubeclient(TEST_CONTEXT)
   end
 
   def kubeclient_builder
-    @kubeclient_builder ||= Krane::KubeclientBuilder.new
+    Krane::KubeclientBuilder.new
   end
 end

--- a/test/helpers/mock_resource.rb
+++ b/test/helpers/mock_resource.rb
@@ -19,7 +19,7 @@ MockResource = Struct.new(:id, :hits_to_complete, :status) do
   def type
     "MockResource"
   end
-  alias_method :kubectl_resource_type, :type
+  alias_method(:kubectl_resource_type, :type)
 
   def group
     "core"

--- a/test/helpers/task_runner_test_helper.rb
+++ b/test/helpers/task_runner_test_helper.rb
@@ -8,7 +8,7 @@ module TaskRunnerTestHelper
         yield fixtures if block_given?
       end
       logging_assertion do |logs|
-        assert_equal true, result, "Deploy failed when it was expected to succeed: \n#{logs}"
+        assert_equal(true, result, "Deploy failed when it was expected to succeed: \n#{logs}")
       end
     end
     reset_logger

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -85,7 +85,7 @@ class SerialDeployTest < Krane::IntegrationTest
     hello_cloud = FixtureSetAssertions::HelloCloud.new(@namespace)
     kubeclient.patch_namespace(hello_cloud.namespace, metadata: { labels: { foo: 'bar' } })
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      assert_deploy_success deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"], wait: false)
+      assert_deploy_success(deploy_fixtures("hello-cloud", subset: ["configmap-data.yml"], wait: false))
     end
 
     %w(
@@ -102,8 +102,8 @@ class SerialDeployTest < Krane::IntegrationTest
 
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
-      refute_nil metric, "Metric #{expected_metric} not emitted"
-      assert_includes metric.tags, "foo:bar", "Metric #{expected_metric} did not have custom tags"
+      refute_nil(metric, "Metric #{expected_metric} not emitted")
+      assert_includes(metric.tags, "foo:bar", "Metric #{expected_metric} did not have custom tags")
     end
   end
 
@@ -129,10 +129,10 @@ class SerialDeployTest < Krane::IntegrationTest
       Krane.all_resources.duration
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
-      refute_nil metric, "Metric #{expected_metric} not emitted"
-      assert_includes metric.tags, "namespace:#{@namespace}", "#{metric.name} is missing namespace tag"
-      assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
-      assert_includes metric.tags, "sha:test-sha", "#{metric.name} is missing sha tag"
+      refute_nil(metric, "Metric #{expected_metric} not emitted")
+      assert_includes(metric.tags, "namespace:#{@namespace}", "#{metric.name} is missing namespace tag")
+      assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag")
+      assert_includes(metric.tags, "sha:test-sha", "#{metric.name} is missing sha tag")
     end
   end
 
@@ -155,8 +155,8 @@ class SerialDeployTest < Krane::IntegrationTest
       Krane.all_resources.duration
     ).each do |expected_metric|
       metric = metrics.find { |m| m.name == expected_metric }
-      refute_nil metric, "Metric #{expected_metric} not emitted"
-      assert_includes metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag"
+      refute_nil(metric, "Metric #{expected_metric} not emitted")
+      assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}", "#{metric.name} is missing context tag")
     end
   end
 

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -555,7 +555,7 @@ unknown field \"myKey\" in io.k8s.apimachinery.pkg.apis.meta.v1.ObjectMeta",
     by_revision = pods.group_by { |pod| pod.spec.containers.first.env.find { |var| var.name == "GITHUB_REV" }.value }
     by_revision.each do |rev, rev_pods|
       statuses = rev_pods.map { |pod| pod.status.to_h }
-      assert_equal 2, rev_pods.length, "#{rev} had #{rev_pods.length} pods (wanted 2). Statuses:\n#{statuses}"
+      assert_equal(2, rev_pods.length, "#{rev} had #{rev_pods.length} pods (wanted 2). Statuses:\n#{statuses}")
     end
     assert_logs_match(%r{Service/multi-replica\s+Selects at least 1 pod})
   end

--- a/test/integration/render_task_test.rb
+++ b/test/integration/render_task_test.rb
@@ -13,7 +13,7 @@ class RenderTaskTest < Krane::TestCase
     assert_render_success(render.run(stream: mock_output_stream))
 
     stdout_assertion do |output|
-      assert_equal output, <<~RENDERED
+      assert_equal(output, <<~RENDERED)
         ---
         apiVersion: v1
         kind: ConfigMap
@@ -77,7 +77,7 @@ class RenderTaskTest < Krane::TestCase
                     name: hello-cloud-configmap-data
                     key: datapoint2
       RENDERED
-      assert_equal expected, output
+      assert_equal(expected, output)
     end
   end
 
@@ -160,7 +160,7 @@ class RenderTaskTest < Krane::TestCase
           supports_partials: "yep"
 
       RENDERED
-      assert_equal expected, output
+      assert_equal(expected, output)
     end
   end
 
@@ -261,9 +261,9 @@ class RenderTaskTest < Krane::TestCase
       render = build_render_task(
         File.join(fixture_path('hello-cloud'), basename)
       )
-      assert_render_success render.run(stream: mock_output_stream)
+      assert_render_success(render.run(stream: mock_output_stream))
       stdout_assertion do |output|
-        assert !output.empty?
+        assert(!output.empty?)
       end
     end
   end
@@ -277,7 +277,7 @@ class RenderTaskTest < Krane::TestCase
 
     assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
-      assert_equal "#{expected}#{expected}", output
+      assert_equal("#{expected}#{expected}", output)
     end
 
     mock_output_stream.rewind
@@ -298,7 +298,7 @@ class RenderTaskTest < Krane::TestCase
 
     assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
-      assert_equal expected, output
+      assert_equal(expected, output)
     end
   end
 
@@ -310,7 +310,7 @@ class RenderTaskTest < Krane::TestCase
 
     assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
-      assert_equal expected, output
+      assert_equal(expected, output)
     end
   end
 
@@ -320,7 +320,7 @@ class RenderTaskTest < Krane::TestCase
     )
     assert_render_success(render.run(stream: mock_output_stream))
     stdout_assertion do |output|
-      assert_equal "", output.strip
+      assert_equal("", output.strip)
     end
     assert_logs_match("Rendered effectively_empty.yml.erb successfully, but the result was blank")
   end
@@ -345,7 +345,7 @@ class RenderTaskTest < Krane::TestCase
     assert_render_success(render.run(stream: mock_output_stream))
 
     stdout_assertion do |output|
-      assert_equal output, <<~RENDERED
+      assert_equal(output, <<~RENDERED)
         ---
         apiVersion: apps/v1
         kind: Deployment
@@ -402,14 +402,14 @@ class RenderTaskTest < Krane::TestCase
   def assert_render_success(result)
     assert_equal(true, result, "Render failed when it was expected to succeed.#{logs_message_if_captured}")
     logging_assertion do |logs|
-      assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
+      assert_match(Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}")
     end
   end
 
   def assert_render_failure(result)
     assert_equal(false, result, "Render succeeded when it was expected to fail.#{logs_message_if_captured}")
     logging_assertion do |logs|
-      assert_match Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}"
+      assert_match(Regexp.new("Result: FAILURE"), logs, "'Result: FAILURE' not found in the following logs:\n#{logs}")
     end
   end
 end

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -103,7 +103,7 @@ class RunnerTaskTest < Krane::IntegrationTest
             retry
           end
         end
-        sleep 0.1
+        sleep(0.1)
       end
     end
     deleter_thread.abort_on_exception = true
@@ -131,14 +131,14 @@ class RunnerTaskTest < Krane::IntegrationTest
 
       first_num_printed = nums_printed[0].to_i
       # The first time we fetch logs, we grab at most 250 lines, so we likely won't print the first few hundred
-      assert first_num_printed < 1500, "Unexpected number of initial logs skipped (started with #{first_num_printed})"
+      assert(first_num_printed < 1500, "Unexpected number of initial logs skipped (started with #{first_num_printed})")
 
       expected_nums = (first_num_printed..5_000).map(&:to_s)
       missing_nums = expected_nums - nums_printed.uniq
-      assert missing_nums.empty?, "Some lines were not streamed: #{missing_nums}"
+      assert(missing_nums.empty?, "Some lines were not streamed: #{missing_nums}")
 
       num_lines_duplicated = nums_printed.length - nums_printed.uniq.length
-      assert num_lines_duplicated.zero?, "#{num_lines_duplicated} lines were duplicated"
+      assert(num_lines_duplicated.zero?, "#{num_lines_duplicated} lines were duplicated")
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -114,8 +114,8 @@ module Krane
       assert_equal(false, result, "Deploy succeeded when it was expected to fail.#{logs_message_if_captured}")
       logging_assertion do |logs|
         cause_string = cause == :timed_out ? "TIMED OUT" : "FAILURE"
-        assert_match Regexp.new("Result: #{cause_string}"), logs,
-          "'Result: #{cause_string}' not found in the following logs:\n#{logs}"
+        assert_match(Regexp.new("Result: #{cause_string}"), logs,
+          "'Result: #{cause_string}' not found in the following logs:\n#{logs}")
       end
     end
     alias_method :assert_restart_failure, :assert_deploy_failure
@@ -124,7 +124,7 @@ module Krane
     def assert_deploy_success(result)
       assert_equal(true, result, "Deploy failed when it was expected to succeed.#{logs_message_if_captured}")
       logging_assertion do |logs|
-        assert_match Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}"
+        assert_match(Regexp.new("Result: SUCCESS"), logs, "'Result: SUCCESS' not found in the following logs:\n#{logs}")
       end
     end
     alias_method :assert_restart_success, :assert_deploy_success
@@ -139,7 +139,7 @@ module Krane
 
         count = logs.scan(regexp).count
         fail_msg = "Expected #{regexp} to appear #{times} time(s) in the log, but it appeared #{count} times"
-        assert_equal times, count, fail_msg
+        assert_equal(times, count, fail_msg)
       end
     end
 
@@ -161,7 +161,7 @@ module Krane
     def refute_logs_match(regexp)
       logging_assertion do |logs|
         regexp = regexp.is_a?(Regexp) ? regexp : Regexp.new(Regexp.escape(regexp))
-        refute regexp =~ logs, "Expected '#{regexp}' not to appear in the following logs:\n#{logs}"
+        refute(regexp =~ logs, "Expected '#{regexp}' not to appear in the following logs:\n#{logs}")
       end
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -226,7 +226,7 @@ module Krane
     end
 
     def task_config(context: KubeclientHelper::TEST_CONTEXT, namespace: @namespace, logger: @logger)
-      @task_config ||= Krane::TaskConfig.new(context, namespace, logger)
+      Krane::TaskConfig.new(context, namespace, logger)
     end
 
     def krane_black_box(command, args = "", stdin: nil)

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -37,10 +37,10 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
 
     assert_equal(kinds.length, 12)
     %w(PriorityClass StorageClass).each do |expected_kind|
-      assert kinds.one? { |k| k.include?(expected_kind) }
+      assert(kinds.one? { |k| k.include?(expected_kind) })
     end
     %w(node namespace).each do |black_lised_kind|
-      assert_empty kinds.select { |k| k.downcase.include?(black_lised_kind) }
+      assert_empty(kinds.select { |k| k.downcase.include?(black_lised_kind) })
     end
   end
 
@@ -52,7 +52,7 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
 
     assert_equal(kinds.length, 25)
     %w(ConfigMap CronJob Deployment).each do |expected_kind|
-      assert kinds.one? { |k| k.include?(expected_kind) }
+      assert(kinds.one? { |k| k.include?(expected_kind) })
     end
   end
 
@@ -63,7 +63,7 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     kinds = crd.prunable_resources(namespaced: true)
 
     %w(batch/v1/Job extensions/v1beta1/Ingress).each do |expected_kind|
-      assert kinds.one? { |k| k.include?(expected_kind) }
+      assert(kinds.one? { |k| k.include?(expected_kind) })
     end
   end
 end

--- a/test/unit/krane/deploy_task_test.rb
+++ b/test/unit/krane/deploy_task_test.rb
@@ -23,4 +23,17 @@ class DeployTaskTest < Krane::TestCase
     assert_logs_match("Configuration invalid")
     assert_logs_match(/File (\S+) does not exist/)
   end
+
+  def test_kubeconfig_configured_correctly
+    task = Krane::DeployTask.new(
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      current_sha: "",
+      filenames: ["unknown"],
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
+  end
 end

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -3,8 +3,9 @@ require 'test_helper'
 
 class EjsonSecretProvisionerTest < Krane::TestCase
   def test_resources_based_on_ejson_file_existence
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
+
     assert_empty(build_provisioner(fixture_path('hello-cloud')).resources)
     refute_empty(build_provisioner(fixture_path('ejson-cloud')).resources)
   end
@@ -18,11 +19,10 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def test_resource_is_built_correctly
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
     resources = build_provisioner(fixture_path('ejson-cloud')).resources
     refute_empty(resources)
-
     secret = resources.find { |s| s.name == 'monitoring-token' }
     refute_nil(secret, "Expected secret not found")
     assert_equal(secret.class, Krane::Secret)
@@ -72,7 +72,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
     Open3.expects(:capture3).with(regexp_matches(/ejson decrypt/))
       .returns([valid_response, "Permissions warning!", stub(success?: true)])
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request
 
     resources = build_provisioner(fixture_path('ejson-cloud')).resources
@@ -110,7 +110,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def test_proactively_validates_resulting_resources_and_raises_without_logging
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request
     Krane::Secret.any_instance.expects(:validation_failed?).returns(true)
     msg = "Generation of Kubernetes secrets from ejson failed: Resulting resource Secret/catphotoscom failed validation"
@@ -121,7 +121,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def test_run_with_selector_does_not_raise_exception
-    stub_server_dry_run_version_request
+    stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request.times(3) # there are three secrets in the ejson
     provisioner = build_provisioner(
       fixture_path('ejson-cloud'),
@@ -132,23 +132,24 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
   private
 
-  def stub_server_dry_run_validation_request
+  def stub_server_dry_run_validation_request(attempts: 3)
     stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
       resp: dummy_secret_hash, json: false,
       kwargs: {
         log_failure: false,
         output_is_sensitive: true,
         retry_whitelist: [:client_timeout, :empty],
-        attempts: 3,
+        attempts: attempts,
       })
   end
 
-  def stub_server_dry_run_version_request
+  def stub_server_dry_run_version_request(attempts: 1)
     stub_kubectl_response("version",
       resp: dummy_version, json: false,
         kwargs: {
           use_namespace: false,
           log_failure: true,
+          attempts: attempts,
         })
   end
 

--- a/test/unit/krane/global_deploy_task_test.rb
+++ b/test/unit/krane/global_deploy_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class GlobalDeployTaskTest < Krane::TestCase
+  def test_kubeconfig_configured_correctly
+    task = Krane::GlobalDeployTask.new(
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      filenames: ["unknown"],
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
+  end
+end

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -111,7 +111,7 @@ class KubectlTest < Krane::TestCase
 
     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
       _out, _err, st = kubectl.run("get", "pods", attempts: 5)
-      refute_predicate st, :success?
+      refute_predicate(st, :success?)
     end
     assert_equal(5, metrics.length)
     assert_equal(["Krane.kubectl.error"], metrics.map(&:name).uniq)
@@ -339,13 +339,13 @@ class KubectlTest < Krane::TestCase
     ktl = build_kubectl
     max_delay_range = ((Krane::Kubectl::MAX_RETRY_DELAY - 0.5)..Krane::Kubectl::MAX_RETRY_DELAY)
     1000.times do
-      assert_includes 0.5..1, ktl.retry_delay(1)
-      assert_includes 1.5..2, ktl.retry_delay(2)
-      assert_includes 3.5..4, ktl.retry_delay(3)
-      assert_includes 7.5..8, ktl.retry_delay(4)
-      assert_includes max_delay_range, ktl.retry_delay(5)
-      assert_includes max_delay_range, ktl.retry_delay(6)
-      assert_includes max_delay_range, ktl.retry_delay(100)
+      assert_includes(0.5..1, ktl.retry_delay(1))
+      assert_includes(1.5..2, ktl.retry_delay(2))
+      assert_includes(3.5..4, ktl.retry_delay(3))
+      assert_includes(7.5..8, ktl.retry_delay(4))
+      assert_includes(max_delay_range, ktl.retry_delay(5))
+      assert_includes(max_delay_range, ktl.retry_delay(6))
+      assert_includes(max_delay_range, ktl.retry_delay(100))
     end
   end
 

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -185,7 +185,7 @@ class KubectlTest < Krane::TestCase
     stub_open3(
       %W(kubectl version --context=testc --request-timeout=#{timeout}),
       resp: '', err: 'bad', success: false
-    )
+    ).times(2)
     assert_raises_message(Krane::KubectlError, "Could not retrieve kubectl version info") do
       build_kubectl.version_info
     end

--- a/test/unit/krane/kubernetes_resource/deployment_test.rb
+++ b/test/unit/krane/kubernetes_resource/deployment_test.rb
@@ -268,12 +268,12 @@ class DeploymentTest < Krane::TestCase
       )
 
       deploy.deploy_started_at = Time.now.utc - Krane::Deployment::TIMEOUT
-      refute deploy.deploy_timed_out?
+      refute(deploy.deploy_timed_out?)
 
       deploy.deploy_started_at = Time.now.utc - Krane::Deployment::TIMEOUT - 1
-      assert deploy.deploy_timed_out?
-      assert_equal "Timeout reason: hard deadline for Deployment\nLatest ReplicaSet: web-1",
-        deploy.timeout_message.strip
+      assert(deploy.deploy_timed_out?)
+      assert_equal("Timeout reason: hard deadline for Deployment\nLatest ReplicaSet: web-1",
+        deploy.timeout_message.strip)
     end
   end
 
@@ -293,11 +293,11 @@ class DeploymentTest < Krane::TestCase
         template: build_deployment_template(status: deployment_status),
         replica_sets: [build_rs_template(status: { "replica" => 1 })]
       )
-      refute deploy.deploy_timed_out?, "Deploy not started shouldn't have timed out"
+      refute(deploy.deploy_timed_out?, "Deploy not started shouldn't have timed out")
 
       deploy.deploy_started_at = Time.now.utc - 3.minutes
-      assert deploy.deploy_timed_out?
-      assert_equal "Timeout reason: ProgressDeadlineExceeded\nLatest ReplicaSet: web-1", deploy.timeout_message.strip
+      assert(deploy.deploy_timed_out?)
+      assert_equal("Timeout reason: ProgressDeadlineExceeded\nLatest ReplicaSet: web-1", deploy.timeout_message.strip)
     end
   end
 
@@ -352,7 +352,7 @@ class DeploymentTest < Krane::TestCase
       )
 
       deploy.deploy_started_at = Time.now.utc - 20.seconds
-      refute deploy.deploy_timed_out?
+      refute(deploy.deploy_timed_out?)
     end
   end
 

--- a/test/unit/krane/kubernetes_resource/service_test.rb
+++ b/test/unit/krane/kubernetes_resource/service_test.rb
@@ -49,10 +49,10 @@ class ServiceTest < Krane::TestCase
     all_services.each { |svc| svc.sync(cache) }
 
     all_services.each do |svc|
-      refute svc.exists?, "#{svc.name} should not have existed"
-      refute svc.deploy_succeeded?, "#{svc.name} should not have succeeded"
-      refute svc.deploy_failed?, "#{svc.name} should not have failed"
-      assert_equal "Not found", svc.status, "#{svc.name} had wrong status"
+      refute(svc.exists?, "#{svc.name} should not have existed")
+      refute(svc.deploy_succeeded?, "#{svc.name} should not have succeeded")
+      refute(svc.deploy_failed?, "#{svc.name} should not have failed")
+      assert_equal("Not found", svc.status, "#{svc.name} had wrong status")
     end
   end
 

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -49,12 +49,12 @@ class KubernetesResourceTest < Krane::TestCase
     cm.deploy_started_at = Time.now.utc
 
     Timecop.freeze(Time.now.utc + 60) do
-      assert cm.deploy_timed_out?
+      assert(cm.deploy_timed_out?)
       expected = <<~STRING
         It is very unusual for this resource type to fail to deploy. Please try the deploy again.
         If that new deploy also fails, contact your cluster administrator.
       STRING
-      assert_equal expected, cm.timeout_message
+      assert_equal(expected, cm.timeout_message)
     end
   end
 
@@ -212,28 +212,28 @@ class KubernetesResourceTest < Krane::TestCase
   def test_deploy_timed_out_respects_hardcoded_timeouts
     Timecop.freeze do
       dummy = DummyResource.new
-      refute dummy.deploy_timed_out?
-      assert_equal 300, dummy.timeout
+      refute(dummy.deploy_timed_out?)
+      assert_equal(300, dummy.timeout)
 
       dummy.deploy_started_at = Time.now.utc - 300
-      refute dummy.deploy_timed_out?
+      refute(dummy.deploy_timed_out?)
 
       dummy.deploy_started_at = Time.now.utc - 301
-      assert dummy.deploy_timed_out?
+      assert(dummy.deploy_timed_out?)
     end
   end
 
   def test_deploy_timed_out_respects_annotation_based_timeouts
     Timecop.freeze do
       custom_dummy = DummyResource.new(definition_extras: build_timeout_metadata("3s"))
-      refute custom_dummy.deploy_timed_out?
-      assert_equal 3, custom_dummy.timeout
+      refute(custom_dummy.deploy_timed_out?)
+      assert_equal(3, custom_dummy.timeout)
 
       custom_dummy.deploy_started_at = Time.now.utc - 3
-      refute custom_dummy.deploy_timed_out?
+      refute(custom_dummy.deploy_timed_out?)
 
       custom_dummy.deploy_started_at = Time.now.utc - 4
-      assert custom_dummy.deploy_timed_out?
+      assert(custom_dummy.deploy_timed_out?)
     end
   end
 
@@ -243,8 +243,8 @@ class KubernetesResourceTest < Krane::TestCase
       dummy.expects(:fetch_debug_logs).never
       dummy.deploy_failed = true
 
-      assert_includes dummy.debug_message, "DummyResource/test: FAILED\n  - Final status: Exists\n"
-      assert_includes dummy.debug_message, Krane::KubernetesResource::DISABLED_LOG_INFO_MESSAGE
+      assert_includes(dummy.debug_message, "DummyResource/test: FAILED\n  - Final status: Exists\n")
+      assert_includes(dummy.debug_message, Krane::KubernetesResource::DISABLED_LOG_INFO_MESSAGE)
     end
   end
 
@@ -254,8 +254,8 @@ class KubernetesResourceTest < Krane::TestCase
       dummy.expects(:fetch_events).never
       dummy.deploy_failed = true
 
-      assert_includes dummy.debug_message, "DummyResource/test: FAILED\n  - Final status: Exists\n"
-      assert_includes dummy.debug_message, Krane::KubernetesResource::DISABLED_EVENT_INFO_MESSAGE
+      assert_includes(dummy.debug_message, "DummyResource/test: FAILED\n  - Final status: Exists\n")
+      assert_includes(dummy.debug_message, Krane::KubernetesResource::DISABLED_EVENT_INFO_MESSAGE)
     end
   end
 

--- a/test/unit/krane/restart_task_test.rb
+++ b/test/unit/krane/restart_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RestartTaskTest < Krane::TestCase
+  def test_kubeconfig_configured_correctly
+    task = Krane::RestartTask.new(
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
+  end
+end

--- a/test/unit/krane/runner_task_test.rb
+++ b/test/unit/krane/runner_task_test.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class RunnerTaskTest < Krane::TestCase
+  def test_kubeconfig_configured_correctly
+    task = Krane::RunnerTask.new(
+      namespace: "something",
+      context: KubeclientHelper::TEST_CONTEXT,
+      logger: logger,
+      kubeconfig: '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', task.task_config.kubeconfig)
+    refute_nil(task.kubeclient_builder, "Expected kubeclient builder.")
+  end
+end

--- a/test/unit/krane/template_sets_test.rb
+++ b/test/unit/krane/template_sets_test.rb
@@ -58,7 +58,7 @@ class TemplateSetsTest < Krane::TestCase
     template_sets = template_sets_from_paths(path)
 
     template_sets.with_resource_definitions_and_filename(raw: true) do |rendered, _|
-      assert_match 'kind: ResourceQuota', rendered
+      assert_match('kind: ResourceQuota', rendered)
     end
   end
 
@@ -71,7 +71,7 @@ class TemplateSetsTest < Krane::TestCase
     file_names = []
     template_sets.with_resource_definitions_and_filename(bindings: { data: "1" }) do |rendered_content, filename|
       file_names << filename
-      refute_empty rendered_content
+      refute_empty(rendered_content)
     end
     assert_equal(paths.map { |f| File.basename(f) }.sort, file_names.sort)
 
@@ -79,7 +79,7 @@ class TemplateSetsTest < Krane::TestCase
     assert_raises(Krane::InvalidTemplateError) do
       template_sets.with_resource_definitions_and_filename(bindings: {}) do |rendered_content, filename|
         file_names << filename
-        refute_empty rendered_content
+        refute_empty(rendered_content)
       end
     end
     assert_equal(file_names.count, 1)

--- a/test/unit/task_config_test.rb
+++ b/test/unit/task_config_test.rb
@@ -20,4 +20,15 @@ class TaskConfigTest < Krane::TestCase
     logger = Krane::FormattedLogger.build(nil, nil)
     assert_equal(task_config(logger: logger).logger, logger)
   end
+
+  def test_kubeconfig_configured_correctly
+    test_task_config = Krane::TaskConfig.new(
+      KubeclientHelper::TEST_CONTEXT,
+      "something",
+      logger,
+      '/some/path.yml',
+    )
+    assert_equal('/some/path.yml', test_task_config.kubeconfig)
+    assert_equal(['/some/path.yml'], test_task_config.kubeclient_builder.kubeconfig_files)
+  end
 end


### PR DESCRIPTION
Addressing context deadline issues associated with the [apply command](https://sh.splunk.shopifysvc.com/en-GB/app/search/causes_of_deploy_failures?form.time_field.earliest=-14d%40d&form.time_field.latest=now&form.repo=*)

Increasing the number of attempts on the apply command will not interfere with the syncing of resources I believe, as the resource watcher is initiated after the apply command and begins syncing [here.](https://github.com/Shopify/krane/blob/master/lib/krane/resource_deployer.rb#L128) As well any apply failures will be caught [here](https://github.com/Shopify/krane/blob/master/lib/krane/resource_deployer.rb#L161) reaching a DeploymentError before a sync. 

The Kubectl apply command is also idempotent, should be safe to retry.


