### PR TITLE
Deploy method override annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## next
+
+*Features*
+- _(experimental)_ Override deploy method via annotation. This feature is considered alpha and should not be considered stable [#753](https://github.com/Shopify/krane/pull/753)
+
+*Enhancements*
 - Increased the number of attempts on kubectl commands during Initializing deploy phase [#749](https://github.com/Shopify/krane/pull/749)
 - Increased attempts on kubectl apply command during deploy [#751](https://github.com/Shopify/krane/pull/751)
 - Whitelist context deadline error during kubctl dry run [#754](https://github.com/Shopify/krane/pull/754)

--- a/README.md
+++ b/README.md
@@ -159,6 +159,11 @@ before the deployment is considered successful.
   - _Default_: `true`
   - `true`: The custom resource will be deployed in the pre-deploy phase.
   - All other values: The custom resource will be deployed in the main deployment phase.
+- `krane.shopify.io/deploy-method-override`: Cause a resource to be deployed by the specified `kubectl` command, instead of the default `apply`.
+  - _Compatibility_: Cannot be used for `PodDisruptionBudget`, since it always uses `create/replace-force`
+  - _Accepted values_: `create`, `replace`, and `replace-force`
+  - _Warning_: Resources whose deploy method is overridden are no longer subject to pruning on deploy.
+  - This feature is _experimental_ and may be removed at any time.
 
 
 ### Running tasks at the beginning of a deploy

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -245,9 +245,7 @@ module Krane
     end
 
     def deploy_method_override
-      override = krane_annotation_value(DEPLOY_METHOD_OVERRIDE_ANNOTATION)
-      return unless override
-      override.to_sym
+      krane_annotation_value(DEPLOY_METHOD_OVERRIDE_ANNOTATION)&.to_sym
     end
 
     def sync_debug_info(kubectl)

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -36,7 +36,7 @@ module Krane
       MSG
 
     ALLOWED_DEPLOY_METHOD_OVERRIDES = %w(apply create replace replace-force)
-    DEPLOY_METHOD_OVERRIDE_ANNOTATION = "alpha/deploy-method-override"
+    DEPLOY_METHOD_OVERRIDE_ANNOTATION = "deploy-method-override"
     TIMEOUT_OVERRIDE_ANNOTATION = "timeout-override"
     LAST_APPLIED_ANNOTATION = "kubectl.kubernetes.io/last-applied-configuration"
     SENSITIVE_TEMPLATE_CONTENT = false

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -35,7 +35,7 @@ module Krane
       If you have reason to believe it will succeed, retry the deploy to continue to monitor the rollout.
       MSG
 
-    ALLOWED_DEPLOY_METHOD_OVERRIDES = %w(create replace replace-force)
+    ALLOWED_DEPLOY_METHOD_OVERRIDES = %w(apply create replace replace-force)
     DEPLOY_METHOD_OVERRIDE_ANNOTATION = "alpha/deploy-method-override"
     TIMEOUT_OVERRIDE_ANNOTATION = "timeout-override"
     LAST_APPLIED_ANNOTATION = "kubectl.kubernetes.io/last-applied-configuration"

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -95,11 +95,10 @@ module Krane
       applyables, individuals = resources.partition { |r| r.deploy_method == :apply }
       # Prunable resources should also applied so that they can  be pruned
       pruneable_types = @prune_whitelist.map { |t| t.split("/").last }
-      applyables += individuals.select { |r| pruneable_types.include?(r.type) }
+      applyables += individuals.select { |r| pruneable_types.include?(r.type) && !r.deploy_method_override }
 
       individuals.each do |individual_resource|
         individual_resource.deploy_started_at = Time.now.utc
-
         case individual_resource.deploy_method
         when :create
           err, status = create_resource(individual_resource)

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -363,6 +363,21 @@ class KubernetesResourceTest < Krane::TestCase
     assert_equal(resource.class, Krane::KubernetesResource)
   end
 
+  def test_deploy_override_method_annotation
+    Krane::KubernetesResource::ALLOWED_DEPLOY_METHOD_OVERRIDES.each do |method|
+      spec = { "kind" => "ConfigMap",
+        "metadata" => {
+          "name" => "foo",
+          "annotations" => {
+            deploy_method_override_annotation_key => method
+          }
+        }
+      }
+      cm = Krane::ConfigMap.new(namespace: 'foo', context: 'none', definition: spec, logger: logger)
+      assert_equal(cm.deploy_method, method.to_sym)
+    end
+  end
+
   private
 
   def kubectl
@@ -462,5 +477,9 @@ class KubernetesResourceTest < Krane::TestCase
 
   def rollout_conditions_annotation_key
     Krane::Annotation.for(Krane::CustomResourceDefinition::ROLLOUT_CONDITIONS_ANNOTATION)
+  end
+
+  def deploy_method_override_annotation_key
+    Krane::Annotation.for(Krane::KubernetesResource::DEPLOY_METHOD_OVERRIDE_ANNOTATION)
   end
 end

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -366,13 +366,12 @@ class KubernetesResourceTest < Krane::TestCase
   def test_deploy_override_method_annotation
     Krane::KubernetesResource::ALLOWED_DEPLOY_METHOD_OVERRIDES.each do |method|
       spec = { "kind" => "ConfigMap",
-        "metadata" => {
-          "name" => "foo",
-          "annotations" => {
-            deploy_method_override_annotation_key => method
-          }
-        }
-      }
+               "metadata" => {
+                 "name" => "foo",
+                 "annotations" => {
+                   deploy_method_override_annotation_key => method,
+                 },
+               } }
       cm = Krane::ConfigMap.new(namespace: 'foo', context: 'none', definition: spec, logger: logger)
       assert_equal(cm.deploy_method, method.to_sym)
     end

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -379,20 +379,6 @@ class KubernetesResourceTest < Krane::TestCase
     assert_equal(resource.class, Krane::KubernetesResource)
   end
 
-  def test_deploy_override_method_annotation
-    Krane::KubernetesResource::ALLOWED_DEPLOY_METHOD_OVERRIDES.each do |method|
-      spec = { "kind" => "ConfigMap",
-               "metadata" => {
-                 "name" => "foo",
-                 "annotations" => {
-                   deploy_method_override_annotation_key => method,
-                 },
-               } }
-      cm = Krane::ConfigMap.new(namespace: 'foo', context: 'none', definition: spec, logger: logger)
-      assert_equal(cm.deploy_method, method.to_sym)
-    end
-  end
-
   private
 
   def kubectl

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -127,6 +127,22 @@ class KubernetesResourceTest < Krane::TestCase
     refute(basic_resource.validation_failed?)
   end
 
+  def test_deploy_method_override_annotation_fails_validation_for_invalid_entry
+    customized_resource = DummyResource.new(definition_extras: build_deploy_method_override_metadata('bad'))
+    assert_equal(:bad, customized_resource.deploy_method_override)
+    customized_resource.validate_definition(kubectl)
+    assert(customized_resource.validation_failed?)
+  end
+
+  def test_deploy_method_override_annotation_validates_for_valid_entries
+    Krane::KubernetesResource::ALLOWED_DEPLOY_METHOD_OVERRIDES.each do |method|
+      customized_resource = DummyResource.new(definition_extras: build_deploy_method_override_metadata(method))
+      assert_equal(method.to_sym, customized_resource.deploy_method_override)
+      customized_resource.validate_definition(kubectl)
+      refute(customized_resource.validation_failed?)
+    end
+  end
+
   def test_timeout_override_lower_bound_validation
     customized_resource = DummyResource.new(definition_extras: build_timeout_metadata("-1S"))
     customized_resource.validate_definition(kubectl)
@@ -392,6 +408,15 @@ class KubernetesResourceTest < Krane::TestCase
       "metadata" => {
         "name" => "customized",
         "annotations" => { timeout_override_annotation_key => value },
+      },
+    }
+  end
+
+  def build_deploy_method_override_metadata(value)
+    {
+      "metadata" => {
+        "name" => "customized",
+        "annotations" => { deploy_method_override_annotation_key => value },
       },
     }
   end


### PR DESCRIPTION
Concerns https://github.com/Shopify/shopify-core-redis-proxy/pull/170

**What are you trying to accomplish with this PR?**
We are reaching the `annotation` size limit for certain `ConfigMap` resources. Note, this is _not_ the 1MiB limit of the `ConfigMap` data, itself, but simply the annotation. One possible strategy to get around this is to preclude the use of the `last-applied-annotation` (which is causing the bloat in size). To do this, we need to stop using `apply` when deploying this resource and instead use `replace`.

To that end, this PR introduces an annotation-driven feature, `krane.shopify.io/alpha/deploy-method-override`. This override accepts one of `apply, create, replace, replace-force` and is used to control the deploy method _at the individual resource level_. I chose this approach because:
- There is already a Krane convention of describing custom behaviour via the use of resource-level annotations (e.g. timeout override, required-rollout).
- The actual code changes are quite light and easily removed should we decide to remove this feature in the future and/or when a more long-term solution to the underlying problem becomes available.

