### PR TITLE
Fix the way environment variable is passed to ejson

### DIFF
--- a/lib/krane/ejson_secret_provisioner.rb
+++ b/lib/krane/ejson_secret_provisioner.rb
@@ -133,7 +133,7 @@ module Krane
     end
 
     def decrypt_ejson(key_dir)
-      out, err, st = Open3.capture3("EJSON_KEYDIR=#{key_dir} ejson decrypt #{@ejson_file}")
+      out, err, st = Open3.capture3({ 'EJSON_KEYDIR' => key_dir.to_s }, 'ejson', 'decrypt', @ejson_file.to_s)
       unless st.success?
         # older ejson versions dump some errors to STDOUT
         msg = err.presence || out

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -50,7 +50,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
   def test_decryption_failure_with_error_on_stdout_reports_error
     # ejson < 1.2 prints errors on stdout
-    Open3.expects(:capture3).with(regexp_matches(/ejson decrypt/))
+    Open3.expects(:capture3).with(instance_of(Hash), 'ejson', 'decrypt', instance_of(String))
       .returns(["Some error from ejson", "", stub(success?: false)])
     msg = "Generation of Kubernetes secrets from ejson failed: Some error from ejson"
     assert_raises_message(Krane::EjsonSecretError, msg) do
@@ -70,7 +70,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
         },
     }.to_json
 
-    Open3.expects(:capture3).with(regexp_matches(/ejson decrypt/))
+    Open3.expects(:capture3).with(instance_of(Hash), 'ejson', 'decrypt', instance_of(String))
       .returns([valid_response, "Permissions warning!", stub(success?: true)])
     stub_server_dry_run_version_request(attempts: 2)
     stub_server_dry_run_validation_request


### PR DESCRIPTION
We just noticed this with @DazWorrall. In our environment `EJSON_KEYDIR` is set, and the way this code works right now doesn't allow to override existing env:

```
>> out, err, st = Open3.capture3({ 'EJSON_KEYDIR' => 'foo' }, "EJSON_KEYDIR=bar echo $EJSON_KEYDIR")
=> ["foo\n", "", #<Process::Status: pid 11963 exit 0>]
```

It's much better to pass the env as a hash, and the command arguments as variadic arguments anyway, as it avoid having to spawn a shell to parse the command.