### PR TITLE
Add version exception for FrontendConfig resource for GKE

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -89,7 +89,7 @@ module Krane
       version_override = { "CronJob" => "v1beta1", "VolumeAttachment" => "v1beta1",
                            "CSIDriver" => "v1beta1", "Ingress" => "v1beta1",
                            "CSINode" => "v1beta1", "Job" => "v1",
-                           "IngressClass" => "v1beta1" }
+                           "IngressClass" => "v1beta1", "FrontendConfig" => "v1beta1" }
 
       pattern = /v(?<major>\d+)(?<pre>alpha|beta)?(?<minor>\d+)?/
       latest = versions.sort_by do |version|


### PR DESCRIPTION
Fixes

```
error: no matches for kind "FrontendConfig" in version "networking.gke.io/v1"
```

when pruning resources on GKE clusters >= 1.17.9-gke.6300

See #687 for more details. Not exactly sure what the best way to test it, it's really just data and would require adding some CRD configured exactly like Google's is to a test cluster.