### PR TITLE
Evaluate progress condition after progress deadline seconds have passed

### DIFF
--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -160,6 +160,7 @@ module Krane
 
     def deploy_failing_to_progress?
       return false unless progress_condition.present?
+      return false unless Time.now.utc - @deploy_started_at > progress_deadline
 
       # This assumes that when the controller bumps the observed generation, it also updates/clears all the status
       # conditions. Specifically, it assumes the progress condition is immediately set to True if a rollout is starting.

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -91,11 +91,6 @@ module Krane
       return false if deploy_failed?
       return super if timeout_override
 
-      if progress_condition.present?
-        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace,
-                                                            progress_condition: deploy_failing_to_progress? })
-      end
-
       # Do not use the hard timeout if progress deadline is set
       progress_condition.present? ? deploy_failing_to_progress? : super
     end

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -155,6 +155,7 @@ module Krane
 
     def deploy_failing_to_progress?
       return false unless progress_condition.present?
+      # ignore progress_condition status until after the progress_deadline is up
       return false if deploy_started? && Time.now.utc - @deploy_started_at < progress_deadline
 
       # This assumes that when the controller bumps the observed generation, it also updates/clears all the status

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -155,7 +155,7 @@ module Krane
 
     def deploy_failing_to_progress?
       return false unless progress_condition.present?
-      # ignore progress_condition status until after the progress_deadline is up
+      # Ensure at least progress_deadline wall clock time has passed before before examining progress_condition
       return false if deploy_started? && Time.now.utc - @deploy_started_at < progress_deadline
 
       # This assumes that when the controller bumps the observed generation, it also updates/clears all the status

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -91,9 +91,11 @@ module Krane
       return false if deploy_failed?
       return super if timeout_override
 
-      if deploy_failing_to_progress?
-        @logger.info("Deploy failing to progress")
-    
+      if progress_condition.present?
+        StatsD.client.increment('kubectl.error', 1, tags: { context: context, namespace: namespace,
+                                                            progress_condition: deploy_failing_to_progress? })
+      end
+
       # Do not use the hard timeout if progress deadline is set
       progress_condition.present? ? deploy_failing_to_progress? : super
     end

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -91,6 +91,9 @@ module Krane
       return false if deploy_failed?
       return super if timeout_override
 
+      if deploy_failing_to_progress?
+        @logger.info("Deploy failing to progress")
+    
       # Do not use the hard timeout if progress deadline is set
       progress_condition.present? ? deploy_failing_to_progress? : super
     end

--- a/lib/krane/kubernetes_resource/deployment.rb
+++ b/lib/krane/kubernetes_resource/deployment.rb
@@ -155,7 +155,7 @@ module Krane
 
     def deploy_failing_to_progress?
       return false unless progress_condition.present?
-      return false unless Time.now.utc - @deploy_started_at > progress_deadline
+      return false if deploy_started? && Time.now.utc - @deploy_started_at < progress_deadline
 
       # This assumes that when the controller bumps the observed generation, it also updates/clears all the status
       # conditions. Specifically, it assumes the progress condition is immediately set to True if a rollout is starting.

--- a/test/unit/krane/kubernetes_resource/deployment_test.rb
+++ b/test/unit/krane/kubernetes_resource/deployment_test.rb
@@ -294,7 +294,8 @@ class DeploymentTest < Krane::TestCase
         replica_sets: [build_rs_template(status: { "replica" => 1 })]
       )
       refute(deploy.deploy_timed_out?, "Deploy not started shouldn't have timed out")
-
+      deploy.deploy_started_at = Time.now.utc
+      refute(deploy.deploy_timed_out?, "Deploy should not fail until after progress deadline seconds passed")
       deploy.deploy_started_at = Time.now.utc - 3.minutes
       assert(deploy.deploy_timed_out?)
       assert_equal("Timeout reason: ProgressDeadlineExceeded\nLatest ReplicaSet: web-1", deploy.timeout_message.strip)
@@ -327,7 +328,7 @@ class DeploymentTest < Krane::TestCase
       deploy.deploy_started_at = Time.now.utc - 11.seconds
       refute(deploy.deploy_timed_out?, "Deploy should not timeout based on progressDeadlineSeconds")
       deploy.deploy_started_at = Time.now.utc - 16.seconds
-      assert(deploy.deploy_timed_out?, "Deploy should timeout according to timoeout override")
+      assert(deploy.deploy_timed_out?, "Deploy should timeout according to timeout override")
       assert_equal(Krane::KubernetesResource::STANDARD_TIMEOUT_MESSAGE + "\nLatest ReplicaSet: web-1",
         deploy.timeout_message.strip)
       assert_equal(deploy.pretty_timeout_type, "timeout override: 15s")


### PR DESCRIPTION
This change checks for the progress condition of a k8s deployment type after the progress deadline seconds have passed.  
ie. when a deployment has been marked as failed to progress, we will wait for at least PDS seconds after a deploy/retry to mark it failed, instead of failing it right away

Note this assumes that `@deploy_started_at` is reset during retries as the DeployTask creates a new instance of [resource_deployer ](https://github.com/Shopify/krane/blob/master/lib/krane/deploy_task.rb#L192) each time.  
 
cc @Shopify/pipeline 
