### PR TITLE
Use v1.15.12 of k8s when starting minikube

### DIFF
--- a/.buildkite/pipeline.nightly.yml
+++ b/.buildkite/pipeline.nightly.yml
@@ -13,31 +13,3 @@ steps:
     env:
       LOGGING_LEVEL: 4
       KUBERNETES_VERSION: v1.15-latest
-  - name: 'Run Test Suite (:kubernetes: 1.14-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: 4
-      KUBERNETES_VERSION: v1.14-latest
-  - name: 'Run Test Suite (:kubernetes: 1.13-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: 4
-      KUBERNETES_VERSION: v1.13-latest
-  - name: 'Run Test Suite (:kubernetes: 1.12-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: 4
-      KUBERNETES_VERSION: v1.12-latest
-  - name: 'Run Test Suite (:kubernetes: 1.11-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: 4
-      KUBERNETES_VERSION: v1.11-latest

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -38,31 +38,3 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.15-latest
-  - label: 'Run Test Suite (:kubernetes: 1.14-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.14-latest
-  - label: 'Run Test Suite (:kubernetes: 1.13-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.13-latest
-  - label: 'Run Test Suite (:kubernetes: 1.12-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.12-latest
-  - label: 'Run Test Suite (:kubernetes: 1.11-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.11-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## next
 
+- Kubernetes 1.14 and lower is no longer officially supported as of this version ([#766](https://github.com/Shopify/krane/pull/766))
+
 ## 2.1.2
 
 - Add version exception for FrontendConfig (GKE resource) [#761](https://github.com/Shopify/krane/pull/761)

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you need the ability to render dynamic values in templates before deploying, 
 ## Prerequisites
 
 * Ruby 2.5+
-* Your cluster must be running Kubernetes v1.11.0 or higher<sup>1</sup>
+* Your cluster must be running Kubernetes v1.15.0 or higher<sup>1</sup>
 
 <sup>1</sup> We run integration tests against these Kubernetes versions. You can find our
 official compatibility chart below.
@@ -90,7 +90,7 @@ official compatibility chart below.
 
 ## Installation
 
-1. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl) (requires v1.11.0 or higher) and make sure it is available in your $PATH
+1. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl) (requires v1.15.0 or higher) and make sure it is available in your $PATH
 2. Set up your [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/) for access to your cluster(s).
 3. `gem install krane`
 
@@ -493,7 +493,7 @@ resource to restart.
 
 ## Prerequisites
 
-* You've already deployed a [`PodTemplate`](https://v1-10.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.11/#podtemplate-v1-core) object with field `template` containing a `Pod` specification that does not include the `apiVersion` or `kind` parameters. An example is provided in this repo in `test/fixtures/hello-cloud/template-runner.yml`.
+* You've already deployed a [`PodTemplate`](https://v1-15.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.15/#podtemplate-v1-core) object with field `template` containing a `Pod` specification that does not include the `apiVersion` or `kind` parameters. An example is provided in this repo in `test/fixtures/hello-cloud/template-runner.yml`.
 * The `Pod` specification in that template has a container named `task-runner`.
 
 Based on this specification `krane run` will create a new pod with the entrypoint of the `task-runner ` container overridden with the supplied arguments.

--- a/bin/setup
+++ b/bin/setup
@@ -9,8 +9,8 @@ if [ ! -x "$(which minikube)" ]; then
 fi
 
 if [ ! -x "$(which kubectl)" ]; then
-  echo -e "\n\033[0;33mPlease install kubectl version 1.11.0 or higher:\nhttps://kubernetes.io/docs/user-guide/prereqs/\033[0m"
+  echo -e "\n\033[0;33mPlease install kubectl version 1.15.0 or higher:\nhttps://kubernetes.io/docs/user-guide/prereqs/\033[0m"
 else
   KUBECTL_VERSION=$(kubectl version --short --client | grep -oe "v[[:digit:]\.]\+")
-  echo -e "\n\033[0;32mKubectl version $KUBECTL_VERSION is already installed. This gem requires version v1.11.0 or greater.\033[0m"
+  echo -e "\n\033[0;32mKubectl version $KUBECTL_VERSION is already installed. This gem requires version v1.15.0 or greater.\033[0m"
 fi

--- a/dev.yml
+++ b/dev.yml
@@ -13,7 +13,7 @@ up:
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q 'Configured')
-      meet: minikube start --kubernetes-version=v1.11.10 --vm-driver=hyperkit
+      meet: minikube start --kubernetes-version=v1.15.xx --vm-driver=hyperkit
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube

--- a/dev.yml
+++ b/dev.yml
@@ -13,7 +13,7 @@ up:
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q 'Configured')
-      meet: minikube start --kubernetes-version=v1.15.xx --vm-driver=hyperkit
+      meet: minikube start --kubernetes-version=v1.15.12 --vm-driver=hyperkit
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube

--- a/lib/krane/common.rb
+++ b/lib/krane/common.rb
@@ -19,5 +19,5 @@ require 'krane/task_config'
 require 'krane/task_config_validator'
 
 module Krane
-  MIN_KUBE_VERSION = '1.11.0'
+  MIN_KUBE_VERSION = '1.15.0'
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
- `dev up` was failing, so bumping to with `Kubernetes 1.11.10 is not supported by this release of minikube`
- this pr bumps the version to `1.15.xx`

**What could go wrong?**
- bumping the version has some other unintended effects

cc @Shopify/pipeline 