### PR TITLE
[Bug Fix] predeploy_sequence is wrong when there are conflicts between built-ins and CRDs

### DIFF
--- a/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-http---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -195,6 +195,7 @@ Style/FrozenStringLiteralComment:
   SupportedStyles:
     - always
     - never
+  SafeAutoCorrect: true
 
 Style/GlobalVars:
   AllowedVariables: []

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -57,24 +57,24 @@ module Krane
     )
 
     def predeploy_sequence
-      default_group = { group: nil }
-      before_crs = %w(
-        ResourceQuota
-        NetworkPolicy
-        ConfigMap
-        PersistentVolumeClaim
-        ServiceAccount
-        Role
-        RoleBinding
-        Secret
-      ).map { |r| [r, default_group] }
+      default_group = { groups: nil }
+      before_crs = {
+        'ResourceQuota' => default_group,
+        'NetworkPolicy' => { groups: %w(extensions networking.k8s.io) },
+        'ConfigMap' => default_group,
+        'PersistentVolumeClaim' => default_group,
+        'ServiceAccount' => default_group,
+        'Role' => default_group,
+        'RoleBinding' => default_group,
+        'Secret' => default_group,
+      }
 
-      after_crs = %w(
-        Pod
-      ).map { |r| [r, default_group] }
+      after_crs = { 'Pod' => default_group }
 
-      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.kind, { group: cr.group }] }
-      Hash[before_crs + crs + after_crs]
+      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.kind, { groups: [cr.group] }] }.to_h
+      predeploy_hash = before_crs
+      predeploy_hash.merge!(crs) { |_k, old, new| { groups: old[:groups] + new[:groups] } }
+      predeploy_hash.merge(after_crs) { |_k, old, new| { groups: old[:groups] + new[:groups] } }
     end
 
     def prune_whitelist
@@ -216,7 +216,7 @@ module Krane
     def deploy_has_priority_resources?(resources)
       resources.any? do |r|
         next unless (pr = predeploy_sequence[r.type])
-        !pr[:group] || pr[:group] == r.group
+        !pr[:groups] || pr[:groups].include?(r.group)
       end
     end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
E.g. If a CRD defines a Kind that is also in our hard coded predeploy_sequence, but with a different group, only one will be pre-deployed. That's a bug. 

Fix: https://github.com/Shopify/krane/issues/773

**How is this accomplished?**
The predeploy sequence now supports multiple groups per Kind.

**What could go wrong?**
This actually isn't the fix, it has a sublte bug where we'll always deploy something with that name ...