### PR TITLE
Only call Oj.mimic_JSON when in a CLI run

### DIFF
--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
-
 require 'krane'
+require 'krane/oj'
 require 'thor'
 require 'krane/cli/version_command'
 require 'krane/cli/restart_command'

--- a/lib/krane/common.rb
+++ b/lib/krane/common.rb
@@ -11,7 +11,6 @@ require 'active_support/core_ext/array/conversions'
 require 'colorized_string'
 
 require 'krane/version'
-require 'krane/oj'
 require 'krane/errors'
 require 'krane/formatted_logger'
 require 'krane/statsd'


### PR DESCRIPTION
### Context

We have a bunch of tests in our CI suite that require krane to test a few deploy stuffs. The problem is that requiring `krane` calls `Oj.mimic_JSON` which cause various issues to us.

### Change

I think krane should only patch JSON when it is ran as CLI, as it has better control of what's running. When used as a library, that's not a good idea to patch core classes like this.

NB: my knowledge of crane and Thor is very limited, so this PR might be totally incorrect.

cc @paracycle @Shopify/test-infra 
