### PR TITLE
Drop support for Ruby 2.5 as its close to EOL

### DIFF
--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -1,6 +1,6 @@
 containers:
   default:
-    docker: circleci/ruby:2.5.7
+    docker: circleci/ruby:2.6.6
 
 steps:
   - label: Lint

--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -8,21 +8,22 @@ steps:
     run:
       - bundle: ~
       - bundle exec rubocop
-  - label: 'Run Test Suite (:kubernetes: 1.20-latest :ruby: 2.7)'
+  - label: 'Run Test Suite (:kubernetes: 1.20-latest :ruby: 3.0)'
     command: bin/ci
     agents:
       queue: k8s-ci
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.20-latest
-      RUBY_VERSION: "2.7"
-  - label: 'Run Test Suite (:kubernetes: 1.19-latest)'
+      RUBY_VERSION: "3.0"
+  - label: 'Run Test Suite (:kubernetes: 1.19-latest :ruby: 2.7)'
     command: bin/ci
     agents:
       queue: k8s-ci
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.19-latest
+      RUBY_VERSION: "2.7"
   - label: 'Run Test Suite (:kubernetes: 1.18-latest)'
     command: bin/ci
     agents:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Other*
+- Dropped support for Ruby 2.5 since it will be EoL shortly. [#782](https://github.com/Shopify/krane/pull/782).
+
 ## 2.1.3
 
 - Add version exception for ServiceNetworkEndpointGroup (GKE resource) [#768](https://github.com/Shopify/krane/pull/768)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## next
 
 *Other*
-- Dropped support for Ruby 2.5 since it will be EoL shortly. [#782](https://github.com/Shopify/krane/pull/782).
+- Dropped support for Ruby 2.5 due to EoL. [#782](https://github.com/Shopify/krane/pull/782).
 
 ## 2.1.3
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you need the ability to render dynamic values in templates before deploying, 
 
 ## Prerequisites
 
-* Ruby 2.5+
+* Ruby 2.6+
 * Your cluster must be running Kubernetes v1.15.0 or higher<sup>1</sup>
 
 <sup>1</sup> We run integration tests against these Kubernetes versions. You can find our

--- a/bin/ci
+++ b/bin/ci
@@ -16,5 +16,5 @@ docker run --rm \
     -e VERBOSE=1 \
     -e PARALLELISM=$PARALLELISM \
     -w /usr/src/app \
-    ruby:"${RUBY_VERSION:-2.5}" \
+    ruby:"${RUBY_VERSION:-2.6.6}" \
     bin/test

--- a/dev.yml
+++ b/dev.yml
@@ -1,7 +1,7 @@
 ---
 name: krane
 up:
-  - ruby: 2.5.7 # Matches gemspec
+  - ruby: 2.6.6 # Matches gemspec
   - bundler
   - homebrew:
     - homebrew/cask/minikube

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 
-  spec.required_ruby_version = '>= 2.5.0'
+  spec.required_ruby_version = '>= 2.6.0'
   spec.add_dependency("activesupport", ">= 5.0")
   spec.add_dependency("kubeclient", "~> 4.3")
   spec.add_dependency("googleauth", "~> 0.8")

--- a/test/helpers/fixture_sets/ejson_cloud.rb
+++ b/test/helpers/fixture_sets/ejson_cloud.rb
@@ -44,7 +44,8 @@ module FixtureSetAssertions
       token_data = { "api-token" => "this-is-the-api-token", "service" => "Datadog" } # Impt: it isn't _service: Datadog
       assert_secret_present("monitoring-token", token_data)
 
-      assert_secret_present("unused-secret", "this-is-for-testing-deletion" => "true")
+      token_data = { "this-is-for-testing-deletion" => "true" }
+      assert_secret_present("unused-secret", token_data)
     end
 
     def assert_web_resources_up


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
- Dropping support for ruby 2.5 in favour of switching the default to 2.6.6

**How is this accomplished?**
- Update gemspec, CI and local dev

**What could go wrong?**
- Unexpected issues with ruby upgrade but the version is being tested on CI
