### PR TITLE
Fix #783 - Adding override for EnvoyFilter to use v1alpha3

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -88,7 +88,8 @@ module Krane
                            "CSIDriver" => "v1beta1", "Ingress" => "v1beta1",
                            "CSINode" => "v1beta1", "Job" => "v1",
                            "IngressClass" => "v1beta1", "FrontendConfig" => "v1beta1",
-                           "ServiceNetworkEndpointGroup" => "v1beta1" }
+                           "ServiceNetworkEndpointGroup" => "v1beta1",
+                           "EnvoyFilter" => "v1alpha3" }
 
       pattern = /v(?<major>\d+)(?<pre>alpha|beta)?(?<minor>\d+)?/
       latest = versions.sort_by do |version|


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix for #783.

**How is this accomplished?**
Add an API version override for kind `EnvoyFilter` which currently only exists in `networking.istio.io/v1alpha3`, not in latest `networking.istio.io/v1beta1`.

**What could go wrong?**
The override doesn't work.
