### PR TITLE
Use client, not server version for server dry run flag

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -279,7 +279,7 @@ module Krane
 
     def validate_resources(resources)
       validate_globals(resources)
-      batch_dry_run_success = validate_dry_run(resources)
+      batch_dry_run_success = kubectl.server_dry_run_enabled? && validate_dry_run(resources)
       Krane::Concurrency.split_across_threads(resources) do |r|
         # No need to pass in kubectl (and do per-resource dry run apply) if batch dry run succeeded
         if batch_dry_run_success

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -101,7 +101,7 @@ module Krane
     end
 
     def dry_run_flag
-      if server_version >= Gem::Version.new("1.18")
+      if client_version >= Gem::Version.new("1.18")
         "--dry-run=server"
       else
         "--server-dry-run"

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -560,7 +560,7 @@ module Krane
 
     # Server side dry run is only supported on apply
     def validate_with_server_side_dry_run(kubectl)
-      command = if kubectl.server_version >= Gem::Version.new('1.18')
+      command = if kubectl.client_version >= Gem::Version.new('1.18')
         ["apply", "-f", file_path, "--dry-run=server", "--output=name"]
       else
         ["apply", "-f", file_path, "--server-dry-run", "--output=name"]

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -193,7 +193,9 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def dummy_version
-    'Server: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.6", GitCommit:"a6a8ec"}'
+    'Server: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.6", GitCommit:"a6a8ec"}' \
+      "\n" \
+      'Client:: version.Info{Major:"1", Minor:"13", GitVersion:"v1.17.0", GitCommit:"70132b"'
   end
 
   def build_provisioner(dir = nil, selector: nil, ejson_keys_secret: dummy_ejson_secret)

--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -195,7 +195,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   def dummy_version
     'Server: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.6", GitCommit:"a6a8ec"}' \
       "\n" \
-      'Client:: version.Info{Major:"1", Minor:"13", GitVersion:"v1.17.0", GitCommit:"70132b"'
+      'Client:: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.6", GitCommit:"70132b"'
   end
 
   def build_provisioner(dir = nil, selector: nil, ejson_keys_secret: dummy_ejson_secret)

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -175,7 +175,7 @@ class KubernetesResourceTest < Krane::TestCase
 
   def test_validate_definition_doesnt_log_raw_output_for_sensitive_resources
     resource = DummySensitiveResource.new
-    kubectl.expects(:server_version).returns(Gem::Version.new('1.20'))
+    kubectl.expects(:client_version).returns(Gem::Version.new('1.20'))
 
     kubectl.expects(:run)
       .with('apply', '-f', "/tmp/foo/bar", "--dry-run=server", '--output=name', {
@@ -197,7 +197,7 @@ class KubernetesResourceTest < Krane::TestCase
       .with('apply', '-f', anything, '--dry-run', '--output=name', anything)
       .returns(["", "", stub(success?: true)])
 
-    kubectl.expects(:server_version).returns(Gem::Version.new('1.20'))
+    kubectl.expects(:client_version).returns(Gem::Version.new('1.20'))
 
     kubectl.expects(:run)
       .with('apply', '-f', anything, '--dry-run=server', '--output=name', anything)
@@ -217,7 +217,7 @@ class KubernetesResourceTest < Krane::TestCase
       .with('apply', '-f', anything, '--dry-run', '--output=name', anything)
       .returns(["", "", stub(success?: true)])
 
-    kubectl.expects(:server_version).returns(Gem::Version.new('1.17'))
+    kubectl.expects(:client_version).returns(Gem::Version.new('1.17'))
 
     kubectl.expects(:run)
       .with('apply', '-f', anything, '--server-dry-run', '--output=name', anything)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Perf testing a new 1.18 core cluster exposed a sleeping error inside the logic we use to determine the appropriate `kubectl` flag for specifying server-side dry-running. Prior to this PR, the __server__ version is checked against 1.18+, when it should be the __client__ version. Unfortunately this issue didn't appear in CI (since client/server are locked together there) and was missed on the 2.1.4 release. 

**How is this accomplished?**
I verified the client/server error by attempting a deploy using various configurations of kubectl client and server versions
<img width="462" alt="Screen Shot 2021-01-26 at 7 40 48 PM" src="https://user-images.githubusercontent.com/31742287/105925571-6548a380-600e-11eb-8246-71651ff14fee.png">

As expected, the client version determines (somewhat obviously) the format of the flag we should pass in. 

**What could go wrong?**
It already went wrong, unfortunately. 
