### PR TITLE
V2.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 2.1.5
+
+- Fix bug where the wrong dry-run flag is used for kubectl if client version is below 1.18 AND server version is 1.18+ [#793](https://github.com/Shopify/krane/pull/793).
+
 ## 2.1.4
 
 *Enhancements*

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.1.4"
+  VERSION = "2.1.5"
 end


### PR DESCRIPTION
Contains fix in #793 (using wrong dry-run flag when kubectl client < 1.18 and server version >= 1.18)