### PR TITLE
Fix #795 - Add override for WorkloadGroup to use v1alpha3

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -90,6 +90,7 @@ module Krane
                            "IngressClass" => "v1beta1", "FrontendConfig" => "v1beta1",
                            "ServiceNetworkEndpointGroup" => "v1beta1",
                            "EnvoyFilter" => "v1alpha3",
+                           "WorkloadGroup" => "v1alpha3",
                            "TCPIngress" => "v1beta1" }
 
       pattern = /v(?<major>\d+)(?<pre>alpha|beta)?(?<minor>\d+)?/


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix for #795.

**How is this accomplished?**
Add an API version override for kind `WorkloadGroup` which currently only exists in `networking.istio.io/v1alpha3`, not in latest `networking.istio.io/v1beta1`.

**What could go wrong?**
The override doesn't work.