### PR TITLE
Increase number of container logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## next
 
+*Other*
+- Increases the number of container logs printed for failures from 25 to 100. [#800](https://github.com/Shopify/krane/pull/800)
+
 ## 2.1.5
 
 - Fix bug where the wrong dry-run flag is used for kubectl if client version is below 1.18 AND server version is 1.18+ [#793](https://github.com/Shopify/krane/pull/793).

--- a/lib/krane/container_logs.rb
+++ b/lib/krane/container_logs.rb
@@ -3,7 +3,7 @@ module Krane
   class ContainerLogs
     attr_reader :lines, :container_name
 
-    DEFAULT_LINE_LIMIT = 25
+    DEFAULT_LINE_LIMIT = 100
 
     def initialize(parent_id:, container_name:, namespace:, context:, logger:)
       @parent_id = parent_id


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
There have been occasions where the number of lines available in the stack trace aren't enough to diagnose a problem for a deploy. This change bumps the number of lines from 25 to 100 so that more information is provided for developers so that they are able to determine the issue.

**Example:**
```
...
/app/.gem/ruby/2.6.0/gems/bundler-2.1.4/exe/bundle:46:in `block in <top (required)>'
/app/.gem/ruby/2.6.0/gems/bundler-2.1.4/lib/bundler/friendly_errors.rb:123:in `with_friendly_errors'
/app/.gem/ruby/2.6.0/gems/bundler-2.1.4/exe/bundle:34:in `<top (required)>'
/app/bin/bundle:5:in `load'
/app/bin/bundle:5:in `<main>'
```
but the line that gives the issue away isn't shown due to the line limit (the error was 76 lines in total)
```
=> Crashed: ArgumentError: Trying to register Bundler::GemfileError for status code 4 but Bundler::GemfileError is already registered
```