### PR TITLE
Configure default line limit for container logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 ## next
 
 *Enhancements*
+- ENV["KRANE_LOG_LINE_LIMIT"] allows the number of container logs printed for failures to be configurable from the 25 line default [#803](https://github.com/Shopify/krane/pull/803).
+
+## 2.1.6
+
+*Enhancements*
 - Remove the need for a hard coded GVK overide list via improvements to cluster discovery [#778](https://github.com/Shopify/krane/pull/778)
 
 *Bug Fixes*

--- a/lib/krane/container_logs.rb
+++ b/lib/krane/container_logs.rb
@@ -3,7 +3,7 @@ module Krane
   class ContainerLogs
     attr_reader :lines, :container_name
 
-    DEFAULT_LINE_LIMIT = 25
+    DEFAULT_LINE_LIMIT = Integer(ENV.fetch('KRANE_LOG_LINE_LIMIT', 25))
 
     def initialize(parent_id:, container_name:, namespace:, context:, logger:)
       @parent_id = parent_id


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
From https://github.com/Shopify/krane/pull/800, it was suggested to make `DEFAULT_LINE_LIMIT` configurable by introducing an environment variable.

**How is this accomplished?**
Turned the constant into a class method, if `ENV["LOG_LINE_LIMIT"]` (name open to suggestions) is not specified or cannot be converted to an integer, the number of lines will default to 25.

