### PR TITLE
bump default timeout to 2 sec

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -101,7 +101,7 @@ module Krane
     end
 
     def kubectl
-      @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true, default_timeout: 1)
+      @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true, default_timeout: 2)
     end
   end
 end


### PR DESCRIPTION
Resolves #805 

Increases default kubectl timeout from 1 to 2 seconds