### PR TITLE
Add support for SOPS-encrypted YAML templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,8 @@ If you need to share a namespace with resources which are managed by other tools
 All templates must be YAML formatted.
 We recommended storing each app's templates in a single directory, `{app root}/config/deploy/{env}`. However, you may use multiple directories.
 
+Templates may be encrypted YAML produced from [Mozilla SOPS](https://github.com/mozilla/sops). To use these templates, ensure that SOPS is installed and configured with the appropriate decryption keys before running `krane deploy` or SOPS-encrypted templates will throw an invalid template error.
+
 If you want dynamic templates, you may render ERB with `krane render` and then pipe that result to `krane deploy -f -`.
 
 ### Customizing behaviour with annotations


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Allow users to encrypt their YAML templates with Mozilla SOPS and have `krane` be able to decrypt and use these upon deploy.

**How is this accomplished?**

Modifying `TemplateSets#templates` to recognize a `sops` key in the YAML as a sign it needs to decrypt a SOPS file, and giving it the logic to do so.

**What could go wrong?**

Users must have `sops` installed and configured on the deploying system in order to use this functionality. Encrypted SOPS files are otherwise invalid templates, and an error is raised if so.
