### PR TITLE
Use same timeout everywhere in resource discovery

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -101,7 +101,7 @@ module Krane
     end
 
     def kubectl
-      @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true, default_timeout: 2)
+      @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true)
     end
   end
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Make krane work in high latency envs

close: https://github.com/Shopify/krane/issues/805

**How is this accomplished?**
Using the same timeout length everywhere.

**What could go wrong?**
Deploys get slower
