### PR TITLE
Relax the dependency on statsd-instrument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+*Other*
+
+- Change `statsd-instrument` dependency constraint to `< 4` [#815](https://github.com/Shopify/krane/pull/815)
+
 ## 2.1.7
 
 *Enhancements*

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("googleauth", "~> 0.8")
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
-  spec.add_dependency("statsd-instrument", ['>= 2.8', "< 3.1"])
+  spec.add_dependency("statsd-instrument", ['>= 2.8', "< 4"])
   spec.add_dependency("oj", "~> 3.0")
   spec.add_dependency("concurrent-ruby", "~> 1.1")
   spec.add_dependency("jsonpath", "~> 0.9.6")


### PR DESCRIPTION
This allows to use `statsd-instrument` `3.1` and up.