### PR TITLE
Release 2.1.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## next
 
+## 2.1.8
+
 *Other*
 
 - Change `statsd-instrument` dependency constraint to `< 4` [#815](https://github.com/Shopify/krane/pull/815)

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.1.7"
+  VERSION = "2.1.8"
 end


### PR DESCRIPTION
I'd like a new release with https://github.com/Shopify/krane/pull/815 as it's preventing upgrading `statsd-instrument`.

