### PR TITLE
Reduce gem size by excluding screenshots

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = %x(git ls-files -z).split("\x0").reject do |f|
-    f.match(%r{^(test|spec|features)/})
+    f.match(%r{^(test|spec|features|screenshots)/})
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Reduce gem size.

**How is this accomplished?**

Removing the README screenshots from the release.

```
$ rake build
$ du -h pkg/*                                                                                    
1.1M	pkg/krane-2.1.8.gem
 88K	pkg/krane-2.1.8.pre.dev.gem
```

**What could go wrong?**

Not much.
