### PR TITLE
dev: switch minikube to homebrew-core

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,5 @@
-inherit_from:
-  - http://shopify.github.io/ruby-style-guide/rubocop.yml
+inherit_gem:
+  rubocop-shopify: rubocop.yml
 
 AllCops:
   TargetRubyVersion: 2.4

--- a/dev.yml
+++ b/dev.yml
@@ -4,7 +4,7 @@ up:
   - ruby: 2.6.6 # Matches gemspec
   - bundler
   - homebrew:
-    - homebrew/cask/minikube
+    - minikube
     - hyperkit
   - custom:
       name: Install the minikube fork of driver-hyperkit

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -57,5 +57,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("ruby-prof")
   spec.add_development_dependency("ruby-prof-flamegraph")
   spec.add_development_dependency("rubocop", "~> 0.89.1")
+  spec.add_development_dependency("rubocop-shopify", "~> 1.0.5")
   spec.add_development_dependency("simplecov")
 end


### PR DESCRIPTION
Krane currently tries to use minikube from Homebrew cask, but that cask was deleted awhile ago: https://github.com/Homebrew/homebrew-cask/commit/2a4a14d67b8b4b4127f9bdb6e4b9dc477aacfa8c

As a result, `dev up` is failing for me since it sees the cask as still uninstalled:

```
┃┏━━ Running `brew install homebrew/cask/minikube` ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃┃    Warning: Use minikube instead of deprecated homebrew/cask/minikube
┃┃
┃┃    Warning: minikube 1.19.0 is already installed and up-to-date.
┃┃
┃┃    To reinstall 1.19.0, run:
┃┃
┃┃      brew reinstall minikube
┃┃
┃┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ (1.43s) ━━
┃ ✗ install packages: failed!
┃ ✗ Error Reason:
┃ ✗   Homebrew packages homebrew/cask/minikube were not installed properly
```

This switches over to use the Homebrew core version.