### PR TITLE
ClusterResourceDiscovery: disable memoization

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -53,26 +53,22 @@ module Krane
     private
 
     def api_paths
-      @api_path_cache["/"] ||= begin
-        raw_json, err, st = kubectl.run("get", "--raw", "/", attempts: 5, use_namespace: false)
-        paths = if st.success?
-          JSON.parse(raw_json)["paths"]
-        else
-          raise FatalKubeAPIError, "Error retrieving raw path /: #{err}"
-        end
-        paths.select { |path| %r{^\/api.*\/v.*$}.match(path) }
+      raw_json, err, st = kubectl.run("get", "--raw", "/", attempts: 5, use_namespace: false)
+      paths = if st.success?
+        JSON.parse(raw_json)["paths"]
+      else
+        raise FatalKubeAPIError, "Error retrieving raw path /: #{err}"
       end
+      paths.select { |path| %r{^\/api.*\/v.*$}.match(path) }
     end
 
     def fetch_api_path(path)
-      @api_path_cache[path] ||= begin
-        raw_json, err, st = kubectl.run("get", "--raw", path, attempts: 2, use_namespace: false)
-        if st.success?
-          JSON.parse(raw_json)
-        else
-          logger.warn("Error retrieving api path: #{err}")
-          {}
-        end
+      raw_json, err, st = kubectl.run("get", "--raw", path, attempts: 2, use_namespace: false)
+      if st.success?
+        JSON.parse(raw_json)
+      else
+        logger.warn("Error retrieving api path: #{err}")
+        {}
       end
     end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
This is slightly a shot in the dark, but as an attempt to resolve #821 I've disabled the memoization that was introduced in #778 in case that's the source of the bug. I'm not sure this is really the solution, but it may be worth testing.

**How is this accomplished?**
I've simply removed instance variable assignments/reads.

**What could go wrong?**
Performance could degrade, although the equivalent calls were not cached before #778.
