### PR TITLE
2.1.9 CHANGELOG + version.rb bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## next
 
+## 2.1.9
+
+*Other*
+
+- Don't package screenshots in the built gem to reduce size [#817](https://github.com/Shopify/krane/pull/817)
+
 ## 2.1.8
 
 *Other*

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.1.8"
+  VERSION = "2.1.9"
 end


### PR DESCRIPTION
patch version increase

- Don't package screenshots in gem build (much smaller package)
