### PR TITLE
Drop 1.15 support

### DIFF
--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -46,3 +46,10 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.17-latest
+  - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.16-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 
 - Fix ERB deprecation of positional arguments [#828](https://github.com/Shopify/krane/pull/828)
 
+*Other*
+- Drop CI support for 1.15 [#826](https://github.com/Shopify/krane/pull/826)
+
 ## 2.1.9
 
 *Other*

--- a/dev.yml
+++ b/dev.yml
@@ -13,7 +13,7 @@ up:
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q 'Configured')
-      meet: minikube start --kubernetes-version=v1.15.12 --vm-driver=hyperkit
+      meet: minikube start --kubernetes-version=v1.18.18 --vm-driver=hyperkit
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube


### PR DESCRIPTION
Dropping 1.15 support as it's quite old now and no longer supported. Most likely will drop 1.16 in the near future as well.

Also updates `dev.yml` to use 1.18.18 for local k8s cluster for development.