### PR TITLE
Dynamically discover cluster url for resource discovery

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -52,8 +52,9 @@ module Krane
 
     private
 
-    def cluster_url
-      @cluster_url ||= begin
+    # During discovery, the api paths may not actually be at the root, so we must programatically find it.
+    def base_api_path
+      @base_api_path ||= begin
         raw_response, err, st = kubectl.run("config", "view", "--minify", "--output",
           "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
         raise FatalKubeAPIError, "Error retrieving cluster url: #{err}" unless st.success?
@@ -64,7 +65,7 @@ module Krane
 
     def api_paths
       @api_path_cache["/"] ||= begin
-        raw_json, err, st = kubectl.run("get", "--raw", cluster_url, attempts: 5, use_namespace: false)
+        raw_json, err, st = kubectl.run("get", "--raw", base_api_path, attempts: 5, use_namespace: false)
         paths = if st.success?
           JSON.parse(raw_json)["paths"]
         else

--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -58,7 +58,7 @@ module Krane
           "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
         raise FatalKubeAPIError, "Error retrieving cluster url: #{err}" unless st.success?
 
-        URI(raw_response).path.blank? ? "/" : URI(raw_response).to_s
+        URI(raw_response).path.blank? ? "/" : URI(raw_response).path
       end
     end
 
@@ -76,7 +76,7 @@ module Krane
 
     def fetch_api_path(path)
       @api_path_cache[path] ||= begin
-        raw_json, err, st = kubectl.run("get", "--raw", File.join(cluster_url, path), attempts: 2, use_namespace: false)
+        raw_json, err, st = kubectl.run("get", "--raw", path, attempts: 2, use_namespace: false)
         if st.success?
           JSON.parse(raw_json)
         else

--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -54,7 +54,8 @@ module Krane
 
     def cluster_url
       @cluster_url ||= begin
-        raw_response, err, st = kubectl.run("config", "view", "--minify", "--output", "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
+        raw_response, err, st = kubectl.run("config", "view", "--minify", "--output",
+          "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
         raise FatalKubeAPIError, "Error retrieving cluster url: #{err}" unless st.success?
 
         URI(raw_response).path.blank? ? "/" : URI(raw_response).to_s

--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -52,7 +52,7 @@ module Krane
 
     private
 
-    def cluster_url()
+    def cluster_url
       @cluster_url ||= begin
         raw_response, err, st = kubectl.run("config", "view", "--minify", "--output", "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
         raise FatalKubeAPIError, "Error retrieving cluster url: #{err}" unless st.success?

--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -111,7 +111,7 @@ module Krane
     end
 
     def kubectl
-      @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true, default_timeout: 2)
+      @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true)
     end
   end
 end

--- a/test/helpers/cluster_resource_discovery_helper.rb
+++ b/test/helpers/cluster_resource_discovery_helper.rb
@@ -15,10 +15,15 @@ module ClusterResourceDiscoveryHelper
   end
 
   def stub_raw_apis(success:)
+
+    Krane::Kubectl.any_instance.stubs(:run).with("config", "view", "--minify", "--output", "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
+      .returns(["", "", stub(success?: success)])
+
+    return unless success
+
     Krane::Kubectl.any_instance.stubs(:run).with("get", "--raw", "/", attempts: 5, use_namespace: false)
       .returns([api_raw_full_response, "", stub(success?: success)])
 
-    return unless success
     paths = JSON.parse(api_raw_full_response)['paths'].select { |p| %r{^\/api.*\/v.*$}.match(p) }
     paths.each do |path|
       Krane::Kubectl.any_instance.stubs(:run).with("get", "--raw", path, attempts: 2, use_namespace: false)

--- a/test/helpers/cluster_resource_discovery_helper.rb
+++ b/test/helpers/cluster_resource_discovery_helper.rb
@@ -15,7 +15,6 @@ module ClusterResourceDiscoveryHelper
   end
 
   def stub_raw_apis(success:)
-
     Krane::Kubectl.any_instance.stubs(:run).with("config", "view", "--minify", "--output", "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
       .returns(["", "", stub(success?: success)])
 

--- a/test/helpers/cluster_resource_discovery_helper.rb
+++ b/test/helpers/cluster_resource_discovery_helper.rb
@@ -15,7 +15,8 @@ module ClusterResourceDiscoveryHelper
   end
 
   def stub_raw_apis(success:)
-    Krane::Kubectl.any_instance.stubs(:run).with("config", "view", "--minify", "--output", "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
+    Krane::Kubectl.any_instance.stubs(:run).with("config", "view", "--minify", "--output",
+      "jsonpath={.clusters[*].cluster.server}", attempts: 5, use_namespace: false)
       .returns(["", "", stub(success?: success)])
 
     return unless success

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -6,7 +6,7 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
 
   def test_fetch_resources_failure
     crd = mocked_cluster_resource_discovery(success: false)
-    assert_raises_message(Krane::FatalKubeAPIError, "Error retrieving raw path /:") do
+    assert_raises_message(Krane::FatalKubeAPIError, "Error retrieving cluster url:") do
       crd.fetch_resources
     end
   end


### PR DESCRIPTION
Replaces #809 

Dynamically discovers the cluster_url to be used for the raw queries during cluster resource discovery (see #809 for further details). I dug through the original implementation a bit and fixed some test regressions that were introduced by the change.

cc @strowi 