### PR TITLE
Add 1.21 CI, remove 1.15 and 1.16

### DIFF
--- a/.shopify-build/krane.yml
+++ b/.shopify-build/krane.yml
@@ -8,6 +8,14 @@ steps:
     run:
       - bundle: ~
       - bundle exec rubocop
+  - label: 'Run Test Suite (:kubernetes: 1.21-latest :ruby: 3.0)'
+    command: bin/ci
+    agents:
+      queue: k8s-ci
+    env:
+      LOGGING_LEVEL: "4"
+      KUBERNETES_VERSION: v1.21-latest
+      RUBY_VERSION: "3.0"
   - label: 'Run Test Suite (:kubernetes: 1.20-latest :ruby: 3.0)'
     command: bin/ci
     agents:
@@ -38,17 +46,3 @@ steps:
     env:
       LOGGING_LEVEL: "4"
       KUBERNETES_VERSION: v1.17-latest
-  - label: 'Run Test Suite (:kubernetes: 1.16-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.16-latest
-  - label: 'Run Test Suite (:kubernetes: 1.15-latest)'
-    command: bin/ci
-    agents:
-      queue: k8s-ci
-    env:
-      LOGGING_LEVEL: "4"
-      KUBERNETES_VERSION: v1.15-latest

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -117,10 +117,10 @@ class KraneDeployTest < Krane::IntegrationTest
       prune_matcher("persistentvolumeclaim", "", "hello-pv-claim"),
     ] # not necessarily listed in this order
     # 1.21 appears to list the ingress as belonging to extensions, not networking.k8s.io
-    expected_pruned << if kube_server_version >= Gem::Version.new("1.17.0") && kube_server_version <= Gem::Version.new("1.21.0")
-      prune_matcher("ingress", "networking.k8s.io", "web")
+    if kube_server_version >= Gem::Version.new("1.17.0") && kube_server_version <= Gem::Version.new("1.21.0")
+      expected_pruned << prune_matcher("ingress", "networking.k8s.io", "web")
     else
-      prune_matcher("ingress", "extensions", "web")
+      expected_pruned << prune_matcher("ingress", "extensions", "web")
     end
     expected_msgs = [/Pruned 2[013] resources and successfully deployed 6 resources/]
     expected_pruned.map do |resource|

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -116,7 +116,8 @@ class KraneDeployTest < Krane::IntegrationTest
       prune_matcher("rolebinding", "rbac.authorization.k8s.io", "role-binding"),
       prune_matcher("persistentvolumeclaim", "", "hello-pv-claim"),
     ] # not necessarily listed in this order
-    expected_pruned << if kube_server_version >= Gem::Version.new('1.17.0')
+    # 1.21 appears to list the ingress as belonging to extensions, not networking.k8s.io
+    expected_pruned << if kube_server_version >= Gem::Version.new("1.17.0") && kube_server_version <= Gem::Version.new("1.21.0")
       prune_matcher("ingress", "networking.k8s.io", "web")
     else
       prune_matcher("ingress", "extensions", "web")


### PR DESCRIPTION
This PR adds 1.21 to our CI pipeline. In addition, it drops 1.15 and 1.16. I'm tempted to drop 1.17 as well, since I believe it's also outside of its support lifecycle.