### PR TITLE
Add option select-any for deployTask and globalDeployTask

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 *Enhancements*
 
-- Add a new option `--select-any` to command `krane deploy` and `krane global-deploy` [#831](https://github.com/Shopify/krane/pull/831)
+- Add a new option `--selector-as-filter` to command `krane deploy` and `krane global-deploy` [#831](https://github.com/Shopify/krane/pull/831)
 
 ## 2.1.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## next
 
+## 2.1.11
+
+*Enhancements*
+
+- Add a new option `--select-any` to command `krane deploy` and `krane global-deploy` [#831](https://github.com/Shopify/krane/pull/831)
+
 ## 2.1.10
 
 *Bug Fixes*

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Refer to `krane help` for the authoritative set of options.
 - `--global-timeout=duration`: Raise a timeout error if it takes longer than _duration_ for any
 resource to deploy.
 - `--selector`: Instructs krane to only prune resources which match the specified label selector, such as `environment=staging`. If you use this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
+- `--select-any`: Instructs krane to deploy resources which match the specified labels in `--selector` even if not all resources are selected. If the option is not present, all resource templates must be selected, otherwise, validation fails.
 - `--no-verify-result`: Skip verification that workloads correctly deployed.
 - `--protected-namespaces=default kube-system kube-public`: Fail validation if a deploy is targeted at a protected namespace.
 - `--verbose-log-prefix`: Add [context][namespace] to the log prefix
@@ -441,6 +442,7 @@ Refer to `krane global-deploy help` for the authoritative set of options.
 - `--filenames / -f [PATHS]`: Accepts a list of directories and/or filenames to specify the set of directories/files that will be deployed. Use `-` to specify STDIN.
 - `--no-prune`: Skips pruning of resources that are no longer in your Kubernetes template set. Not recommended, as it allows your namespace to accumulate cruft that is not reflected in your deploy directory.
 - `--selector`: Instructs krane to only prune resources which match the specified label selector, such as `environment=staging`. By using this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
+- `--select-any`: Instructs krane to deploy resources which match the specified labels in `--selector` even if not all resources are selected. If the option is not present, all resource templates must be selected, otherwise, validation fails.
 - `--global-timeout=duration`: Raise a timeout error if it takes longer than _duration_ for any
 resource to deploy.
 - `--no-verify-result`: Skip verification that resources correctly deployed.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Refer to `krane help` for the authoritative set of options.
 - `--global-timeout=duration`: Raise a timeout error if it takes longer than _duration_ for any
 resource to deploy.
 - `--selector`: Instructs krane to only prune resources which match the specified label selector, such as `environment=staging`. If you use this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
-- `--select-any`: Instructs krane to deploy resources which match the specified labels in `--selector` even if not all resources are selected. If the option is not present, all resource templates must be selected, otherwise, validation fails.
+- `--selector-as-filter`: Instructs krane to only deploy resources that are filtered by the specified labels in `--selector`. The deploy will not fail if not all resources match the labels.
 - `--no-verify-result`: Skip verification that workloads correctly deployed.
 - `--protected-namespaces=default kube-system kube-public`: Fail validation if a deploy is targeted at a protected namespace.
 - `--verbose-log-prefix`: Add [context][namespace] to the log prefix
@@ -442,7 +442,7 @@ Refer to `krane global-deploy help` for the authoritative set of options.
 - `--filenames / -f [PATHS]`: Accepts a list of directories and/or filenames to specify the set of directories/files that will be deployed. Use `-` to specify STDIN.
 - `--no-prune`: Skips pruning of resources that are no longer in your Kubernetes template set. Not recommended, as it allows your namespace to accumulate cruft that is not reflected in your deploy directory.
 - `--selector`: Instructs krane to only prune resources which match the specified label selector, such as `environment=staging`. By using this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
-- `--select-any`: Instructs krane to deploy resources which match the specified labels in `--selector` even if not all resources are selected. If the option is not present, all resource templates must be selected, otherwise, validation fails.
+- `--selector-as-filter`: Instructs krane to only deploy resources that are filtered by the specified labels in `--selector`. The deploy will not fail if not all resources match the labels.
 - `--global-timeout=duration`: Raise a timeout error if it takes longer than _duration_ for any
 resource to deploy.
 - `--no-verify-result`: Skip verification that resources correctly deployed.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Refer to `krane help` for the authoritative set of options.
 - `--global-timeout=duration`: Raise a timeout error if it takes longer than _duration_ for any
 resource to deploy.
 - `--selector`: Instructs krane to only prune resources which match the specified label selector, such as `environment=staging`. If you use this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
-- `--selector-as-filter`: Instructs krane to only deploy resources that are filtered by the specified labels in `--selector`. The deploy will not fail if not all resources match the labels.
+- `--selector-as-filter`: Instructs krane to only deploy resources that are filtered by the specified labels in `--selector`. The deploy will not fail if not all resources match the labels. This is useful if you only want to deploy a subset of resources within a given YAML file. See [Sharing a namespace](#sharing-a-namespace) below.
 - `--no-verify-result`: Skip verification that workloads correctly deployed.
 - `--protected-namespaces=default kube-system kube-public`: Fail validation if a deploy is targeted at a protected namespace.
 - `--verbose-log-prefix`: Add [context][namespace] to the log prefix
@@ -132,6 +132,8 @@ By default, krane will prune any resources in the target namespace which have th
 If you need to, you may specify `--no-prune` to disable all pruning behaviour, but this is not recommended.
 
 If you need to share a namespace with resources which are managed by other tools or indeed other krane deployments, you can supply the `--selector` option, such that only resources with labels matching the selector are considered for pruning.
+
+If you need to share a namespace with different set of resources using the same YAML file, you can supply the `--selector` and `--selector-as-filter` options, such that only the resources that match with the labels will be deployed. In each run of deploy, you can use different labels in `--selector` to deploy a different set of resources. Only the deployed resources in each run are considered for pruning.
 
 ### Using templates
 
@@ -442,7 +444,7 @@ Refer to `krane global-deploy help` for the authoritative set of options.
 - `--filenames / -f [PATHS]`: Accepts a list of directories and/or filenames to specify the set of directories/files that will be deployed. Use `-` to specify STDIN.
 - `--no-prune`: Skips pruning of resources that are no longer in your Kubernetes template set. Not recommended, as it allows your namespace to accumulate cruft that is not reflected in your deploy directory.
 - `--selector`: Instructs krane to only prune resources which match the specified label selector, such as `environment=staging`. By using this option, all resource templates must specify matching labels. See [Sharing a namespace](#sharing-a-namespace) below.
-- `--selector-as-filter`: Instructs krane to only deploy resources that are filtered by the specified labels in `--selector`. The deploy will not fail if not all resources match the labels.
+- `--selector-as-filter`: Instructs krane to only deploy resources that are filtered by the specified labels in `--selector`. The deploy will not fail if not all resources match the labels. This is useful if you only want to deploy a subset of resources within a given YAML file. See [Sharing a namespace](#sharing-a-namespace) below.
 - `--global-timeout=duration`: Raise a timeout error if it takes longer than _duration_ for any
 resource to deploy.
 - `--no-verify-result`: Skip verification that resources correctly deployed.

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -26,7 +26,8 @@ module Krane
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
         "selector-as-filter" => { type: :boolean,
-                                  desc: "Use --selector as a label filter to select a subset of resources to deploy",
+                                  desc: "Use --selector as a label filter to deploy only a subset "\
+                                    "of the provided resources",
                                   default: false },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: false },
@@ -41,6 +42,10 @@ module Krane
 
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
         selector_as_filter = options['selector-as-filter']
+
+        if selector_as_filter && selector.to_s.empty?
+          raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
+        end
 
         logger = ::Krane::FormattedLogger.build(namespace, context,
           verbose_prefix: options['verbose-log-prefix'])

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -43,7 +43,7 @@ module Krane
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
         selector_as_filter = options['selector-as-filter']
 
-        if selector_as_filter && selector.to_s.empty?
+        if selector_as_filter && !selector
           raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
         end
 

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -25,9 +25,9 @@ module Krane
                      default: true },
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
-        "select-any" => { type: :boolean,
-                          desc: "Enable selecting a subset of resources to deploy without validation failure",
-                          default: false },
+        "selector-as-filter" => { type: :boolean,
+                                  desc: "Use --selector as a label filter to select a subset of resources to deploy",
+                                  default: false },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: false },
         "verify-result" => { type: :boolean, default: true,
@@ -40,7 +40,7 @@ module Krane
         require 'krane/label_selector'
 
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
-        select_any = options['select-any']
+        selector_as_filter = options['selector-as-filter']
 
         logger = ::Krane::FormattedLogger.build(namespace, context,
           verbose_prefix: options['verbose-log-prefix'])
@@ -64,7 +64,7 @@ module Krane
             logger: logger,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,
-            select_any: select_any,
+            selector_as_filter: selector_as_filter,
             protected_namespaces: protected_namespaces,
           )
 

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -25,6 +25,9 @@ module Krane
                      default: true },
         "selector" => { type: :string, banner: "'label=value'",
                         desc: "Select workloads by selector(s)" },
+        "select-any" => { type: :boolean,
+                          desc: "Enable selecting a subset of resources to deploy without validation failure",
+                          default: false },
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: false },
         "verify-result" => { type: :boolean, default: true,
@@ -37,6 +40,7 @@ module Krane
         require 'krane/label_selector'
 
         selector = ::Krane::LabelSelector.parse(options[:selector]) if options[:selector]
+        select_any = options['select-any']
 
         logger = ::Krane::FormattedLogger.build(namespace, context,
           verbose_prefix: options['verbose-log-prefix'])
@@ -60,6 +64,7 @@ module Krane
             logger: logger,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,
+            select_any: select_any,
             protected_namespaces: protected_namespaces,
           )
 

--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -16,6 +16,9 @@ module Krane
                              desc: "Verify workloads correctly deployed" },
         "selector" => { type: :string, banner: "'label=value'", required: true,
                         desc: "Select workloads owned by selector(s)" },
+        "select-any" => { type: :boolean,
+                          desc: "Enable selecting a subset of resources to deploy without validation failure",
+                          default: false },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that match"\
                      " the provided selector and do not appear in the provided templates",
                      default: true },
@@ -28,6 +31,7 @@ module Krane
         require 'krane/duration_parser'
 
         selector = ::Krane::LabelSelector.parse(options[:selector])
+        select_any = options['select-any']
 
         filenames = options[:filenames].dup
         filenames << "-" if options[:stdin]
@@ -41,6 +45,7 @@ module Krane
             filenames: paths,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,
+            select_any: select_any,
           )
 
           deploy.run!(

--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -16,9 +16,9 @@ module Krane
                              desc: "Verify workloads correctly deployed" },
         "selector" => { type: :string, banner: "'label=value'", required: true,
                         desc: "Select workloads owned by selector(s)" },
-        "select-any" => { type: :boolean,
-                          desc: "Enable selecting a subset of resources to deploy without validation failure",
-                          default: false },
+        "selector-as-filter" => { type: :boolean,
+                                  desc: "Use --selector as a label filter to select a subset of resources to deploy",
+                                  default: false },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that match"\
                      " the provided selector and do not appear in the provided templates",
                      default: true },
@@ -31,7 +31,7 @@ module Krane
         require 'krane/duration_parser'
 
         selector = ::Krane::LabelSelector.parse(options[:selector])
-        select_any = options['select-any']
+        selector_as_filter = options['selector-as-filter']
 
         filenames = options[:filenames].dup
         filenames << "-" if options[:stdin]
@@ -45,7 +45,7 @@ module Krane
             filenames: paths,
             global_timeout: ::Krane::DurationParser.new(options["global-timeout"]).parse!.to_i,
             selector: selector,
-            select_any: select_any,
+            selector_as_filter: selector_as_filter,
           )
 
           deploy.run!(

--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -17,7 +17,8 @@ module Krane
         "selector" => { type: :string, banner: "'label=value'", required: true,
                         desc: "Select workloads owned by selector(s)" },
         "selector-as-filter" => { type: :boolean,
-                                  desc: "Use --selector as a label filter to select a subset of resources to deploy",
+                                  desc: "Use --selector as a label filter to deploy only a subset "\
+                                    "of the provided resources",
                                   default: false },
         "prune" => { type: :boolean, desc: "Enable deletion of resources that match"\
                      " the provided selector and do not appear in the provided templates",
@@ -32,6 +33,10 @@ module Krane
 
         selector = ::Krane::LabelSelector.parse(options[:selector])
         selector_as_filter = options['selector-as-filter']
+
+        if selector_as_filter && selector.to_s.empty?
+          raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
+        end
 
         filenames = options[:filenames].dup
         filenames << "-" if options[:stdin]

--- a/lib/krane/cli/global_deploy_command.rb
+++ b/lib/krane/cli/global_deploy_command.rb
@@ -34,7 +34,7 @@ module Krane
         selector = ::Krane::LabelSelector.parse(options[:selector])
         selector_as_filter = options['selector-as-filter']
 
-        if selector_as_filter && selector.to_s.empty?
+        if selector_as_filter && !selector
           raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
         end
 

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -298,9 +298,9 @@ module Krane
       batchable_resources, individuals = partition_dry_run_resources(resources.dup)
       batch_dry_run_success = kubectl.server_dry_run_enabled? && validate_dry_run(batchable_resources)
       individuals += batchable_resources unless batch_dry_run_success
+      resources.select! { |r| r.selected?(@selector) } if @selector_as_filter
       Krane::Concurrency.split_across_threads(resources) do |r|
-        r.validate_definition(kubectl: kubectl, selector: @selector, selector_as_filter: @selector_as_filter,
-          dry_run: individuals.include?(r))
+        r.validate_definition(kubectl: kubectl, selector: @selector, dry_run: individuals.include?(r))
       end
       failed_resources = resources.select(&:validation_failed?)
       if failed_resources.present?
@@ -311,7 +311,6 @@ module Krane
         end
         raise FatalDeploymentError, "Template validation failed"
       end
-      resources.select! { |r| r.selected?(@selector) }
     end
     measure_method(:validate_resources)
 

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -275,7 +275,7 @@ module Krane
 
       confirm_ejson_keys_not_prunable if prune
       @logger.info("Using resource selector #{@selector}") if @selector
-      @logger.info("Can deploy a subset of resources") if @selector && @selector_as_filter
+      @logger.info("Only deploying resources filtered by labels in selector") if @selector && @selector_as_filter
       @namespace_tags |= tags_from_namespace_labels
       @logger.info("All required parameters and files are present")
     end

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -100,13 +100,13 @@ module Krane
     # @param bindings [Hash] Bindings parsed by Krane::BindingsParser
     # @param global_timeout [Integer] Timeout in seconds
     # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector
-    # @param select_any [Boolean] Allow selecting a subset of Kubernetes resource templates to deploy
+    # @param selector_as_filter [Boolean] Allow selecting a subset of Kubernetes resource templates to deploy
     # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
     # @param protected_namespaces [Array<String>] Array of protected Kubernetes namespaces (defaults
     #   to Krane::DeployTask::PROTECTED_NAMESPACES)
     # @param render_erb [Boolean] Enable ERB rendering
     def initialize(namespace:, context:, current_sha: nil, logger: nil, kubectl_instance: nil, bindings: {},
-      global_timeout: nil, selector: nil, select_any: false, filenames: [], protected_namespaces: nil,
+      global_timeout: nil, selector: nil, selector_as_filter: false, filenames: [], protected_namespaces: nil,
       render_erb: false, kubeconfig: nil)
       @logger = logger || Krane::FormattedLogger.build(namespace, context)
       @template_sets = TemplateSets.from_dirs_and_files(paths: filenames, logger: @logger, render_erb: render_erb)
@@ -119,7 +119,7 @@ module Krane
       @kubectl = kubectl_instance
       @global_timeout = global_timeout
       @selector = selector
-      @select_any = select_any
+      @selector_as_filter = selector_as_filter
       @protected_namespaces = protected_namespaces || PROTECTED_NAMESPACES
       @render_erb = render_erb
     end
@@ -275,7 +275,7 @@ module Krane
 
       confirm_ejson_keys_not_prunable if prune
       @logger.info("Using resource selector #{@selector}") if @selector
-      @logger.info("Can select any resource") if @selector && @select_any
+      @logger.info("Can deploy a subset of resources") if @selector && @selector_as_filter
       @namespace_tags |= tags_from_namespace_labels
       @logger.info("All required parameters and files are present")
     end
@@ -299,7 +299,7 @@ module Krane
       batch_dry_run_success = kubectl.server_dry_run_enabled? && validate_dry_run(batchable_resources)
       individuals += batchable_resources unless batch_dry_run_success
       Krane::Concurrency.split_across_threads(resources) do |r|
-        r.validate_definition(kubectl: kubectl, selector: @selector, select_any: @select_any,
+        r.validate_definition(kubectl: kubectl, selector: @selector, selector_as_filter: @selector_as_filter,
           dry_run: individuals.include?(r))
       end
       failed_resources = resources.select(&:validation_failed?)

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -133,8 +133,9 @@ module Krane
     def validate_resources(resources)
       validate_globals(resources)
 
+      resources.select! { |r| r.selected?(@selector) } if @selector_as_filter
       Concurrency.split_across_threads(resources) do |r|
-        r.validate_definition(kubectl: @kubectl, selector: @selector, selector_as_filter: @selector_as_filter)
+        r.validate_definition(kubectl: @kubectl, selector: @selector)
       end
 
       failed_resources = resources.select(&:validation_failed?)
@@ -146,8 +147,6 @@ module Krane
         end
         raise FatalDeploymentError, "Template validation failed"
       end
-
-      resources.select! { |r| r.selected?(@selector) }
     end
     measure_method(:validate_resources)
 

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -33,9 +33,9 @@ module Krane
     # @param context [String] Kubernetes context (*required*)
     # @param global_timeout [Integer] Timeout in seconds
     # @param selector [Hash] Selector(s) parsed by Krane::LabelSelector (*required*)
-    # @param select_any [Boolean] Allow selecting a subset of Kubernetes resource templates to deploy
+    # @param selector_as_filter [Boolean] Allow selecting a subset of Kubernetes resource templates to deploy
     # @param filenames [Array<String>] An array of filenames and/or directories containing templates (*required*)
-    def initialize(context:, global_timeout: nil, selector: nil, select_any: false,
+    def initialize(context:, global_timeout: nil, selector: nil, selector_as_filter: false,
       filenames: [], logger: nil, kubeconfig: nil)
       template_paths = filenames.map { |path| File.expand_path(path) }
 
@@ -44,7 +44,7 @@ module Krane
         logger: @task_config.logger, render_erb: false)
       @global_timeout = global_timeout
       @selector = selector
-      @select_any = select_any
+      @selector_as_filter = selector_as_filter
     end
 
     # Runs the task, returning a boolean representing success or failure
@@ -134,7 +134,7 @@ module Krane
       validate_globals(resources)
 
       Concurrency.split_across_threads(resources) do |r|
-        r.validate_definition(kubectl: @kubectl, selector: @selector, select_any: @select_any)
+        r.validate_definition(kubectl: @kubectl, selector: @selector, selector_as_filter: @selector_as_filter)
       end
 
       failed_resources = resources.select(&:validation_failed?)

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -134,9 +134,9 @@ module Krane
       Kubeclient::Resource.new(@definition)
     end
 
-    def validate_definition(kubectl:, selector: nil, select_any: false, dry_run: true)
+    def validate_definition(kubectl:, selector: nil, selector_as_filter: false, dry_run: true)
       @validation_errors = []
-      validate_selector(selector, select_any) if selector
+      validate_selector(selector, selector_as_filter) if selector
       validate_timeout_annotation
       validate_deploy_method_override_annotation
       validate_spec_with_kubectl(kubectl) if dry_run
@@ -534,8 +534,8 @@ module Krane
       @definition.dig("metadata", "annotations", Annotation.for(suffix))
     end
 
-    def validate_selector(selector, select_any)
-      return if select_any
+    def validate_selector(selector, selector_as_filter)
+      return if selector_as_filter
       # If not select any, we have to ensure all kubernetes resource templates contain the selector labels.
       if labels.nil?
         @validation_errors << "selector #{selector} passed in, but no labels were defined"

--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -134,9 +134,9 @@ module Krane
       Kubeclient::Resource.new(@definition)
     end
 
-    def validate_definition(kubectl:, selector: nil, selector_as_filter: false, dry_run: true)
+    def validate_definition(kubectl:, selector: nil, dry_run: true)
       @validation_errors = []
-      validate_selector(selector, selector_as_filter) if selector
+      validate_selector(selector) if selector
       validate_timeout_annotation
       validate_deploy_method_override_annotation
       validate_spec_with_kubectl(kubectl) if dry_run
@@ -534,9 +534,7 @@ module Krane
       @definition.dig("metadata", "annotations", Annotation.for(suffix))
     end
 
-    def validate_selector(selector, selector_as_filter)
-      return if selector_as_filter
-      # If not select any, we have to ensure all kubernetes resource templates contain the selector labels.
+    def validate_selector(selector)
       if labels.nil?
         @validation_errors << "selector #{selector} passed in, but no labels were defined"
         return

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.1.11"
+  VERSION = "2.1.10"
 end

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.1.10"
+  VERSION = "2.1.11"
 end

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -95,6 +95,28 @@ class DeployTest < Krane::TestCase
     end
   end
 
+  def test_deploy_fails_with_selector_as_filter_but_without_selector
+    selector = Krane::LabelSelector.new('key' => 'value')
+    Krane::LabelSelector.expects(:parse).returns(selector)
+    set_krane_deploy_expectations(new_args: {
+      filenames: ['/my/file/path'],
+      selector: selector,
+      selector_as_filter: true,
+    })
+    flags = '-f /my/file/path --selector key:value --selector_as_filter'
+    krane_deploy!(flags: flags)
+
+    flags = '-f /my/file/path --selector-as-filter'
+    krane = Krane::CLI::Krane.new(
+      [deploy_task_config.namespace, deploy_task_config.context],
+      flags.split
+    )
+    assert_raises_message(Thor::RequiredArgumentMissingError,
+      "--selector must be set when --selector-as-filter is set") do
+      krane.invoke("deploy")
+    end
+  end
+
   def test_stdin_flag_deduped_if_specified_multiple_times
     Dir.mktmpdir do |tmp_path|
       $stdin.expects("read").returns("").times(2)

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -103,7 +103,7 @@ class DeployTest < Krane::TestCase
       selector: selector,
       selector_as_filter: true,
     })
-    flags = '-f /my/file/path --selector key:value --selector_as_filter'
+    flags = '-f /my/file/path --selector key:value --selector-as-filter'
     krane_deploy!(flags: flags)
 
     flags = '-f /my/file/path --selector-as-filter'

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -140,6 +140,7 @@ class DeployTest < Krane::TestCase
         logger: logger,
         global_timeout: 300,
         selector: nil,
+        select_any: false,
         protected_namespaces: ["default", "kube-system", "kube-public"],
       }.merge(new_args),
       run_args: {

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -140,7 +140,7 @@ class DeployTest < Krane::TestCase
         logger: logger,
         global_timeout: 300,
         selector: nil,
-        select_any: false,
+        selector_as_filter: false,
         protected_namespaces: ["default", "kube-system", "kube-public"],
       }.merge(new_args),
       run_args: {

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -120,6 +120,7 @@ class GlobalDeployTest < Krane::TestCase
         filenames: ['/tmp'],
         global_timeout: 300,
         selector: 'name=web',
+        select_any: false,
       }.merge(new_args),
       run_args: {
         verify_result: true,

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -120,7 +120,7 @@ class GlobalDeployTest < Krane::TestCase
         filenames: ['/tmp'],
         global_timeout: 300,
         selector: 'name=web',
-        select_any: false,
+        selector_as_filter: false,
       }.merge(new_args),
       run_args: {
         verify_result: true,

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -88,7 +88,7 @@ class GlobalDeployTest < Krane::TestCase
       selector: "key=value",
       selector_as_filter: true,
     })
-    flags = '-f /my/file/path --selector key:value --selector_as_filter'
+    flags = '-f /my/file/path --selector key:value --selector-as-filter'
     krane_global_deploy!(flags: flags)
 
     flags = '-f /my/file/path --selector-as-filter'

--- a/test/exe/global_deploy_test.rb
+++ b/test/exe/global_deploy_test.rb
@@ -80,6 +80,28 @@ class GlobalDeployTest < Krane::TestCase
     end
   end
 
+  def test_deploy_fails_selector_required
+    selector = Krane::LabelSelector.new('key' => 'value')
+    Krane::LabelSelector.expects(:parse).returns(selector)
+    set_krane_global_deploy_expectations!(new_args: {
+      filenames: ['/my/file/path'],
+      selector: "key=value",
+      selector_as_filter: true,
+    })
+    flags = '-f /my/file/path --selector key:value --selector_as_filter'
+    krane_global_deploy!(flags: flags)
+
+    flags = '-f /my/file/path --selector-as-filter'
+    krane = Krane::CLI::Krane.new(
+      [task_config.context],
+      flags.split
+    )
+    assert_raises_message(Thor::RequiredArgumentMissingError,
+      "No value provided for required options '--selector'") do
+      krane.invoke("global_deploy")
+    end
+  end
+
   def test_deploy_parses_selector
     selector = 'name=web'
     set_krane_global_deploy_expectations!(new_args: { selector: selector })

--- a/test/fixtures/slow-cloud/web-deploy-3.yml
+++ b/test/fixtures/slow-cloud/web-deploy-3.yml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web3
+  labels:
+    name: web3
+    branch: staging
+    app: slow-cloud
+  annotations:
+    shipit.shopify.io/restart: "true"
+    krane.shopify.io/required-rollout: maxUnavailable
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      name: web3
+      app: slow-cloud
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+  template:
+    metadata:
+      labels:
+        name: web3
+        app: slow-cloud
+        sha: deploy3
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+      - name: app
+        image: busybox
+        imagePullPolicy: IfNotPresent
+        command: ["tail", "-f", "/dev/null"]
+        ports:
+        - containerPort: 80
+          name: http

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -89,7 +89,8 @@ module FixtureDeployHelper
   end
 
   def deploy_dirs_without_profiling(dirs, wait: true, prune: true, bindings: {},
-    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil, selector: nil, select_any: false,
+    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil,
+    selector: nil, selector_as_filter: false,
     protected_namespaces: nil, render_erb: false)
     kubectl_instance = build_kubectl
 
@@ -103,7 +104,7 @@ module FixtureDeployHelper
       bindings: bindings,
       global_timeout: global_timeout,
       selector: selector,
-      select_any: select_any,
+      selector_as_filter: selector_as_filter,
       protected_namespaces: protected_namespaces,
       render_erb: render_erb
     )

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -89,7 +89,7 @@ module FixtureDeployHelper
   end
 
   def deploy_dirs_without_profiling(dirs, wait: true, prune: true, bindings: {},
-    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil, selector: nil,
+    sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil, selector: nil, select_any: false,
     protected_namespaces: nil, render_erb: false)
     kubectl_instance = build_kubectl
 
@@ -103,6 +103,7 @@ module FixtureDeployHelper
       bindings: bindings,
       global_timeout: global_timeout,
       selector: selector,
+      select_any: select_any,
       protected_namespaces: protected_namespaces,
       render_erb: render_erb
     )

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -173,7 +173,7 @@ class KraneDeployTest < Krane::IntegrationTest
       selector_as_filter: true))
     assert_logs_match_all([
       "Using resource selector branch=master",
-      "Can deploy a subset of resources",
+      "Only deploying resources filtered by labels in selector",
     ], in_order: true)
     # Ensure only the selected resource is deployed
     deployments = apps_v1_kubeclient.get_deployments(namespace: @namespace)
@@ -186,7 +186,7 @@ class KraneDeployTest < Krane::IntegrationTest
       selector_as_filter: true))
     assert_logs_match_all([
       "Using resource selector branch=staging",
-      "Can deploy a subset of resources",
+      "Only deploying resources filtered by labels in selector",
     ], in_order: true)
     # Ensure the not selected resource is not pruned
     deployments = apps_v1_kubeclient.get_deployments(namespace: @namespace)

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -170,10 +170,10 @@ class KraneDeployTest < Krane::IntegrationTest
     # Deploy only the resource matching the selector without valiation error
     assert_deploy_success(deploy_fixtures("slow-cloud", subset: ['web-deploy-1.yml', 'web-deploy-3.yml'],
       selector: Krane::LabelSelector.parse("branch=master"),
-      select_any: true))
+      selector_as_filter: true))
     assert_logs_match_all([
       "Using resource selector branch=master",
-      "Can select any resource",
+      "Can deploy a subset of resources",
     ], in_order: true)
     # Ensure only the selected resource is deployed
     deployments = apps_v1_kubeclient.get_deployments(namespace: @namespace)
@@ -183,10 +183,10 @@ class KraneDeployTest < Krane::IntegrationTest
     # Deploy another resource with a different selector
     assert_deploy_success(deploy_fixtures("slow-cloud", subset: ['web-deploy-1.yml', 'web-deploy-3.yml'],
       selector: Krane::LabelSelector.parse("branch=staging"),
-      select_any: true))
+      selector_as_filter: true))
     assert_logs_match_all([
       "Using resource selector branch=staging",
-      "Can select any resource",
+      "Can deploy a subset of resources",
     ], in_order: true)
     # Ensure the not selected resource is not pruned
     deployments = apps_v1_kubeclient.get_deployments(namespace: @namespace)

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -166,7 +166,7 @@ class KraneDeployTest < Krane::IntegrationTest
     assert_equal("master", deployments.first.metadata.labels.branch)
   end
 
-  def test_select_any
+  def test_selector_as_filter
     # Deploy only the resource matching the selector without validation error
     assert_deploy_success(deploy_fixtures("slow-cloud", subset: ['web-deploy-1.yml', 'web-deploy-3.yml'],
       selector: Krane::LabelSelector.parse("branch=master"),

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -167,7 +167,7 @@ class KraneDeployTest < Krane::IntegrationTest
   end
 
   def test_select_any
-    # Deploy only the resource matching the selector without valiation error
+    # Deploy only the resource matching the selector without validation error
     assert_deploy_success(deploy_fixtures("slow-cloud", subset: ['web-deploy-1.yml', 'web-deploy-3.yml'],
       selector: Krane::LabelSelector.parse("branch=master"),
       selector_as_filter: true))


### PR DESCRIPTION
Related PR: https://github.com/Shopify/gkrane-config/pull/45

**What are you trying to accomplish with this PR?**
Currently option `--selector` for sub command `krane deploy` and `krane global-deploy` will cause validation failure if any k8s resources in templates (--filenames) does not match the label selectors. This will cause problems when we want to deploy a subset of k8s resources. 

**How is this accomplished?**
Adding a new option `selector-as-filter` in boolean with `default` value of false. If set to `true`, selector validation will be skipped. Only resources with matching labels will be deployed and be prunable.
This allows us to deploy none or a subset of resources. It will help us to address canary and production deploy where the 2 sets of resources share the same namespace and same templates file directory.

**What could go wrong?**
The new option has default value of `false`, which will not change current selector behaviour. Therefore it should be backward compatible. This is not a breaking change.

```
krane help deploy                                                                                                                                                                                                   
Usage:
  krane deploy NAMESPACE CONTEXT

Options:
  f, [--filenames=config/deploy/production config/deploy/my-extra-resource.yml]  # Directories and files that contains the configuration to apply
      [--stdin], [--no-stdin]                                                    # [DEPRECATED] Read resources from stdin
      [--global-timeout=duration]                                                # Max duration to monitor workloads correctly deployed
                                                                                 # Default: 300s
      [--protected-namespaces=namespace1 namespace2 namespaceN]                  # Enable deploys to a list of selected namespaces; set to an empty string to disable
                                                                                 # Default: ["default", "kube-system", "kube-public"]
      [--prune], [--no-prune]                                                    # Enable deletion of resources that do not appear in the template dir
                                                                                 # Default: true
      [--selector='label=value']                                                 # Select workloads by selector(s)
      [--selector-as-filter], [--no-selector-as-filter]                          # Use --selector as a label filter to select a subset of resources to deploy
      [--verbose-log-prefix], [--no-verbose-log-prefix]                          # Add [context][namespace] to the log prefix
      [--verify-result], [--no-verify-result]                                    # Verify workloads correctly deployed
                                                                                 # Default: true

krane help global-deploy                                                                                                                                                                                             
Usage:
  krane global-deploy CONTEXT --selector='label=value'

Options:
  f, [--filenames=config/deploy/production config/deploy/my-extra-resource.yml]  # Directories and files that contains the configuration to apply
      [--stdin], [--no-stdin]                                                    # [DEPRECATED] Read resources from stdin
      [--global-timeout=duration]                                                # Max duration to monitor workloads correctly deployed
                                                                                 # Default: 300s
      [--verify-result], [--no-verify-result]                                    # Verify workloads correctly deployed
                                                                                 # Default: true
      --selector='label=value'                                                   # Select workloads owned by selector(s)
      [--selector-as-filter], [--no-selector-as-filter]                          # Use --selector as a label filter to select a subset of resources to deploy
      [--prune], [--no-prune]                                                    # Enable deletion of resources that match the provided selector and do not appear in the provided templates

```
