### PR TITLE
Add fail-on-image-pull flag (default true) to deploy_command

### DIFF
--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -32,7 +32,9 @@ module Krane
         "verbose-log-prefix" => { type: :boolean, desc: "Add [context][namespace] to the log prefix",
                                   default: false },
         "verify-result" => { type: :boolean, default: true,
-                             desc: "Verify workloads correctly deployed" },
+                             desc: "Verify workloads correctly deployed" }
+        "fail-on-image-pull" => { type: :boolean, default: true,
+                                  desc: "When false, 404s on image pulls will not fail Pod resources" }
       }
 
       def self.from_options(namespace, context, options)
@@ -46,6 +48,8 @@ module Krane
         if selector_as_filter && !selector
           raise(Thor::RequiredArgumentMissingError, '--selector must be set when --selector-as-filter is set')
         end
+
+        fail_on_image_pull = options['fail-on-image-pull']
 
         logger = ::Krane::FormattedLogger.build(namespace, context,
           verbose_prefix: options['verbose-log-prefix'])
@@ -71,6 +75,7 @@ module Krane
             selector: selector,
             selector_as_filter: selector_as_filter,
             protected_namespaces: protected_namespaces,
+            fail_on_image_pull: fail_on_image_pull
           )
 
           deploy.run!(

--- a/lib/krane/kubernetes_resource/pod.rb
+++ b/lib/krane/kubernetes_resource/pod.rb
@@ -9,7 +9,7 @@ module Krane
       Preempting
     )
 
-    attr_accessor :stream_logs
+    attr_accessor :stream_logs, :fail_on_image_pull
 
     def initialize(namespace:, context:, definition:, logger:,
       statsd_tags: nil, parent: nil, deploy_started_at: nil, stream_logs: false)
@@ -222,7 +222,7 @@ module Krane
         if limbo_reason == "CrashLoopBackOff"
           exit_code = @status.dig('lastState', 'terminated', 'exitCode')
           "Crashing repeatedly (exit #{exit_code}). See logs for more information."
-        elsif limbo_reason == "ErrImagePull" && limbo_message.match(/not found/i)
+        elsif fail_on_image_pull && limbo_reason == "ErrImagePull" && limbo_message.match(/not found/i)
           "Failed to pull image #{@image}. "\
           "Did you wait for it to be built and pushed to the registry before deploying?"
         elsif limbo_reason == "CreateContainerConfigError"


### PR DESCRIPTION
# Closes #819 

Adds a flag to `krane deploy`: `fail-on-image-pull[=true]`. If set to false, no image pull errors will fail the deploy. Otherwise, we preserve existing behaviour and fail image pull errors only in the case of 404s.

TODO: test