### PR TITLE
Support restart task for StatefulSet with updateStrategy: OnDelete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+*Enhancements*
+
+- Support restart task for stateful sets that use the `OnDelete` strategy [#840](https://github.com/Shopify/krane/pull/840)
+
 ## 2.4.0
 
 *Enhancements*

--- a/lib/krane/kubernetes_resource/stateful_set.rb
+++ b/lib/krane/kubernetes_resource/stateful_set.rb
@@ -27,13 +27,11 @@ module Krane
                        "Consider switching to rollingUpdate.")
           @success_assumption_warning_shown = true
         end
-        true
-      else
-        observed_generation == current_generation &&
-        status_data['currentRevision'] == status_data['updateRevision'] &&
-        desired_replicas == status_data['readyReplicas'].to_i &&
-        desired_replicas == status_data['currentReplicas'].to_i
       end
+      observed_generation == current_generation &&
+      status_data['currentRevision'] == status_data['updateRevision'] &&
+      desired_replicas == status_data['readyReplicas'].to_i &&
+      desired_replicas == status_data['currentReplicas'].to_i
     end
 
     def deploy_failed?

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -35,6 +35,28 @@ class RestartTaskTest < Krane::IntegrationTest
     refute(fetch_restarted_at("redis"), "no restart annotation env on fresh deployment")
   end
 
+  def test_restart_statefulset_on_delete_restarts_child_pods
+    result = deploy_fixtures("hello-cloud", subset: "stateful_set.yml") do |fixtures|
+      statefulset = fixtures["stateful_set.yml"]["StatefulSet"].first
+      statefulset["spec"]["updateStrategy"] = { "type" => "OnDelete" }
+    end
+    assert_deploy_success(result)
+
+    restart = build_restart_task
+    assert_restart_success(restart.perform)
+
+    assert_logs_match_all([
+      "Configured to restart all workloads with the `shipit.shopify.io/restart` annotation",
+      "Triggered `StatefulSet/stateful-busybox` restart",
+      "`StatefulSet/stateful-busybox` has updateStrategy: OnDelete,Restarting by forcefully deleting child pods",
+      "Waiting for rollout",
+      "Result: SUCCESS",
+      "Successfully restarted 3 resources",
+      %r{StatefulSet/stateful-busybox.* 2 replicas},
+    ],
+      in_order: true)
+  end
+
   def test_restart_by_selector
     assert_deploy_success(deploy_fixtures("branched",
       bindings: { "branch" => "master" },

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -41,9 +41,16 @@ class RestartTaskTest < Krane::IntegrationTest
       statefulset["spec"]["updateStrategy"] = { "type" => "OnDelete" }
     end
     assert_deploy_success(result)
+    before_pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=stateful-busybox").map do |p|
+      p.metadata.name
+    end
 
     restart = build_restart_task
     assert_restart_success(restart.perform)
+    after_pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=stateful-busybox").map do |p|
+      p.metadata.name
+    end
+    refute_equal(before_pods.sort, after_pods.sort)
 
     assert_logs_match_all([
       "Configured to restart all workloads with the `shipit.shopify.io/restart` annotation",

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -48,7 +48,7 @@ class RestartTaskTest < Krane::IntegrationTest
     assert_logs_match_all([
       "Configured to restart all workloads with the `shipit.shopify.io/restart` annotation",
       "Triggered `StatefulSet/stateful-busybox` restart",
-      "`StatefulSet/stateful-busybox` has updateStrategy: OnDelete,Restarting by forcefully deleting child pods",
+      "`StatefulSet/stateful-busybox` has updateStrategy: OnDelete, Restarting by forcefully deleting child pods",
       "Waiting for rollout",
       "Result: SUCCESS",
       "Successfully restarted 3 resources",

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -51,7 +51,7 @@ class RestartTaskTest < Krane::IntegrationTest
       "`StatefulSet/stateful-busybox` has updateStrategy: OnDelete, Restarting by forcefully deleting child pods",
       "Waiting for rollout",
       "Result: SUCCESS",
-      "Successfully restarted 3 resources",
+      "Successfully restarted 1 resource",
       %r{StatefulSet/stateful-busybox.* 2 replicas},
     ],
       in_order: true)

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -42,13 +42,13 @@ class RestartTaskTest < Krane::IntegrationTest
     end
     assert_deploy_success(result)
     before_pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=stateful-busybox").map do |p|
-      p.metadata.name
+      p.metadata.uid
     end
 
     restart = build_restart_task
     assert_restart_success(restart.perform)
     after_pods = kubeclient.get_pods(namespace: @namespace, label_selector: "name=stateful-busybox").map do |p|
-      p.metadata.name
+      p.metadata.uid
     end
     refute_equal(before_pods.sort, after_pods.sort)
 


### PR DESCRIPTION
Builds on https://github.com/Shopify/krane/pull/836 by handling the special case of a StatefulSet having `updatStrategy: OnDelete`. In this case, we need to find all pods with an owner reference to the targeted StatefulSet: this is accomplished using the [UID of the StatefulSet](https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids).

More info on owner references can be found [here](https://kubernetes.io/docs/concepts/overview/working-with-objects/owners-dependents/).
