### PR TITLE
Update codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @Shopify/krane
+* @Shopify/app-lifecycle


### PR DESCRIPTION
@Shopify/krane is an outdated team and should be retired. Application Lifecycle is the most appropriate team to steward this repo for now.