### PR TITLE
Fix compatibility with Psych 4

### DIFF
--- a/lib/krane/renderer.rb
+++ b/lib/krane/renderer.rb
@@ -58,7 +58,7 @@ module Krane
       template = File.read(partial_path)
       expanded_template = ERB.new(template, trim_mode: '-').result(erb_binding)
 
-      docs = Psych.parse_stream(expanded_template, partial_path)
+      docs = Psych.parse_stream(expanded_template, filename: partial_path)
       # If the partial contains multiple documents or has an explicit document header,
       # we know it cannot validly be indented in the parent, so return it immediately.
       return expanded_template unless docs.children.one? && docs.children.first.implicit


### PR DESCRIPTION
Passing the filename as postional argument have been deprecated for ages
and removed in Psych 4.
