### PR TITLE
use minikube with docker driver for M1 support

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -5,15 +5,10 @@ up:
   - bundler
   - homebrew:
     - minikube
-    - hyperkit
-  - custom:
-      name: Install the minikube fork of driver-hyperkit
-      met?: command -v docker-machine-driver-hyperkit
-      meet: curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit && sudo install -o root -g wheel -m 4755 docker-machine-driver-hyperkit /usr/local/bin/ && rm ./docker-machine-driver-hyperkit
   - custom:
       name: Minikube Cluster
       met?: test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q 'Configured')
-      meet: minikube start --kubernetes-version=v1.18.18 --vm-driver=hyperkit
+      meet: minikube start --driver=docker --kubernetes-version=v1.18.18
       down: minikube stop
 commands:
   reset-minikube: minikube delete && rm -rf ~/.minikube


### PR DESCRIPTION

**What are you trying to accomplish with this PR?**

For testing at Shopify on local hardware, we will now use `minikube` with `docker` driver. Hyperkit will not support `darwin-amd64`. 

**What could go wrong?**

Nothing - only impacts local testing.
