### PR TITLE
Switch to kind for local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ dev/flamegraph.svg
 dev/profile
 dev/flamegraph.pl
 .local-context
+bin/kind

--- a/bin/test
+++ b/bin/test
@@ -27,7 +27,7 @@ if [[ ${PARALLELISM:=0} -lt 1 ]]; then
   fi
 fi
 
-if [[ "${CI}" != "0" ]]; then
+if [[ "${CI:-0}" != "0" ]]; then
   SCRIPT_DIR="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
   echo "kind-kind" > "${SCRIPT_DIR}/../.local-context"
   PARALLELISM=2

--- a/dev.yml
+++ b/dev.yml
@@ -3,20 +3,20 @@ name: krane
 up:
   - ruby: 2.6.6 # Matches gemspec
   - bundler
-  - homebrew:
-    - minikube
-    - hyperkit
   - custom:
-      name: Install the minikube fork of driver-hyperkit
-      met?: command -v docker-machine-driver-hyperkit
-      meet: curl -LO https://storage.googleapis.com/minikube/releases/latest/docker-machine-driver-hyperkit && sudo install -o root -g wheel -m 4755 docker-machine-driver-hyperkit /usr/local/bin/ && rm ./docker-machine-driver-hyperkit
+      name: Install Kubernetes in Docker (KinD)
+      met?: bin/kind version 2>&1 | grep -q v0.11.1
+      meet: |
+        mkdir -p bin
+        curl -sLo bin/kind "https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-darwin-amd64"
+        chmod +x bin/kind
   - custom:
-      name: Minikube Cluster
-      met?: test $(minikube status | grep Running | wc -l) -ge 2 && $(minikube status | grep -q 'Configured')
-      meet: minikube start --kubernetes-version=v1.18.18 --vm-driver=hyperkit
-      down: minikube stop
+      name: Create KinD Cluster
+      met?: bin/kind get clusters | grep -q krane
+      meet: bin/kind create cluster --name krane
+      down: |
+        ((bin/kind get clusters | grep -q krane) && bin/kind delete cluster --name krane) || true
 commands:
-  reset-minikube: minikube delete && rm -rf ~/.minikube
   test:
     run: bin/test
   tophat:

--- a/test/helpers/kubeclient_helper.rb
+++ b/test/helpers/kubeclient_helper.rb
@@ -6,7 +6,7 @@ module KubeclientHelper
   if File.exist?(LOCAL_CONTEXT_OVERRIDE_PATH)
     TEST_CONTEXT = File.read(LOCAL_CONTEXT_OVERRIDE_PATH).split.first
   end
-  TEST_CONTEXT ||= "minikube"
+  TEST_CONTEXT ||= "kind-krane"
 
   def kubeclient
     kubeclient_builder.build_v1_kubeclient(TEST_CONTEXT)


### PR DESCRIPTION
Follow on to #839 - we should use the same tool in dev and CI for consistency, and this also brings krane into line with other Shopify kube projects (e.g. cloudbuddies, from where these dev commands are inspired). I have a full passing test suite using this branch locally via `dev up && dev test`.