### PR TITLE
Limit to active-support < 7.0

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = "https://rubygems.org"
 
   spec.required_ruby_version = '>= 2.6.0'
-  spec.add_dependency("activesupport", ">= 5.0")
+  spec.add_dependency("activesupport", ">= 5.0", "<7.0")
   spec.add_dependency("cgi")
   spec.add_dependency("date")
   spec.add_dependency("kubeclient", "~> 4.3")


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Lots of broken tests in https://github.com/Shopify/krane/pull/852 so limiting to active_support < 7.0 for now. This fixes ShopifyBuild CI https://github.com/Shopify/shopify-build/pull/3542.

See https://github.com/Shopify/krane/pull/852

**How is this accomplished?**
Lots of broken tests in https://github.com/Shopify/krane/pull/852 so limiting to active_support < 7.0 for now.

**What could go wrong?**
n/a
