### PR TITLE
Fix local (client) dry-runs with kubectl 1.23.0

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -584,7 +584,12 @@ module Krane
     # If the resource template uses generateName, validating with apply will fail
     def validate_with_local_dry_run(kubectl)
       verb = deploy_method == :apply ? "apply" : "create"
-      command = [verb, "-f", file_path, "--dry-run", "--output=name"]
+      command = if kubectl.client_version >= Gem::Version.new('1.18')
+        [verb, "-f", file_path, "--dry-run=client" "--output=name"]
+      else
+        [verb, "-f", file_path, "--dry-run" "--output=name"]
+      end
+
       kubectl.run(*command, log_failure: false, output_is_sensitive: sensitive_template_content?,
         retry_whitelist: [:client_timeout, :empty, :context_deadline], attempts: 3, use_namespace: !global?)
     end

--- a/test/unit/krane/kubernetes_resource/deployment_test.rb
+++ b/test/unit/krane/kubernetes_resource/deployment_test.rb
@@ -361,7 +361,7 @@ class DeploymentTest < Krane::TestCase
 
   def stub_validation_dry_run(out: "", err: "", status: SystemExit.new(0))
     kubectl.expects(:run)
-      .with('apply', '-f', anything, '--dry-run', '--output=name', anything)
+      .with('apply', '-f', anything, '--dry-run=client', '--output=name', anything)
       .returns([out, err, status])
   end
 

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -194,7 +194,7 @@ class KubernetesResourceTest < Krane::TestCase
   def test_validate_definition_ignores_server_dry_run_unsupported_by_webhook_response
     resource = DummySensitiveResource.new
     kubectl.expects(:run)
-      .with('apply', '-f', anything, '--dry-run', '--output=name', anything)
+      .with('apply', '-f', anything, '--dry-run=client', '--output=name', anything)
       .returns(["", "", stub(success?: true)])
 
     kubectl.expects(:client_version).returns(Gem::Version.new('1.20'))
@@ -214,7 +214,7 @@ class KubernetesResourceTest < Krane::TestCase
   def test_validate_definition_ignores_server_dry_run_unsupported_by_webhook_response_k8s_1_17
     resource = DummySensitiveResource.new
     kubectl.expects(:run)
-      .with('apply', '-f', anything, '--dry-run', '--output=name', anything)
+      .with('apply', '-f', anything, '--dry-run=client', '--output=name', anything)
       .returns(["", "", stub(success?: true)])
 
     kubectl.expects(:client_version).returns(Gem::Version.new('1.17'))


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fix #850, which breaks all krane deployments if using kubectl `1.23.0`.

**How is this accomplished?**

By explicitly setting `--dry-run=client` instead of `--dry-run`

**What could go wrong?**

Older versions might not work, but this PR only sets `--dry-run=client` if the client is greater than or equal to 1.18 when the change (and deprecation notice) was added.
