### PR TITLE
Require active_support, CI fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,23 @@ jobs:
         # Match kind images with chosen version https://github.com/kubernetes-sigs/kind/releases
         - ruby: '3.0'
           kind_version: 'v0.11.1'
+          kubernetes_version: '1.21.1'
           kind_image: 'kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6'
         - ruby: '3.0'
           kind_version: 'v0.11.1'
+          kubernetes_version: '1.20.7'
           kind_image: 'kindest/node:v1.20.7@sha256:cbeaf907fc78ac97ce7b625e4bf0de16e3ea725daf6b04f930bd14c67c671ff9'
         - ruby: '2.7'
           kind_version: 'v0.11.1'
+          kubernetes_version: '1.19.11'
           kind_image: 'kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729'
         - ruby: '2.6.6'
           kind_version: 'v0.11.1'
+          kubernetes_version: '1.18.19'
           kind_image: '1.18: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c'
         - ruby: '2.6.6'
           kind_version: 'v0.11.1'
+          kubernetes_version: '1.17.17'
           kind_image: 'kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00'
 
     steps:
@@ -41,6 +46,13 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
+
+      - name: Setup kubectl
+        run: |
+          mkdir -p "${GITHUB_WORKSPACE}/bin"
+          curl -o "${GITHUB_WORKSPACE}/bin/kubectl" -LO "https://dl.k8s.io/release/v${{ matrix.kubernetes_version }}/bin/linux/amd64/kubectl"
+          chmod +x "${GITHUB_WORKSPACE}/bin/kubectl"
+          echo "PATH=$GITHUB_WORKSPACE/bin:${PATH}" >> $GITHUB_ENV
 
       - uses: engineerd/setup-kind@v0.5.0
         with:

--- a/lib/krane/common.rb
+++ b/lib/krane/common.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/core_ext/object/blank'
 require 'active_support/core_ext/hash/reverse_merge'
 require 'active_support/core_ext/hash/slice'

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -131,9 +131,6 @@ class RunnerTaskTest < Krane::IntegrationTest
       nums_printed = all_logs.scan(/Line (\d+)$/).flatten
 
       first_num_printed = nums_printed[0].to_i
-      # The first time we fetch logs, we grab at most 250 lines, so we likely won't print the first few hundred
-      assert(first_num_printed < 1500, "Unexpected number of initial logs skipped (started with #{first_num_printed})")
-
       expected_nums = (first_num_printed..5_000).map(&:to_s)
       missing_nums = expected_nums - nums_printed.uniq
       assert(missing_nums.empty?, "Some lines were not streamed: #{missing_nums}")


### PR DESCRIPTION
Supersedes #852 

* Correctly require `active_support`
* Fetch specific kubectl version in CI ([context](https://github.com/Shopify/krane/pull/852#issuecomment-996637419))
* Fix a flaky test

About the test: on slow nodes or alongside noisy neighbours, many more log lines are printed than the test assumes. It doesn't seem like a worthwhile assertion to me, so I just removed it.