### PR TITLE
Configure a more useful Actions job name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ jobs:
   ruby-tests:
     runs-on: ubuntu-latest
 
+    name: "Tests - Ruby ${{ matrix.ruby }} with k8s ${{ matrix.kubernetes_version }}"
     strategy:
       fail-fast: false
       matrix:

--- a/test/integration/runner_task_test.rb
+++ b/test/integration/runner_task_test.rb
@@ -31,7 +31,7 @@ class RunnerTaskTest < Krane::IntegrationTest
     timeout = 5 # seconds
 
     task_runner = build_task_runner(global_timeout: timeout)
-    result = task_runner.run(**run_params(log_lines: timeout * 4, log_interval: 1))
+    result = task_runner.run(**run_params(log_lines: timeout * 10, log_interval: 1))
     assert_task_run_failure(result, :timed_out)
 
     assert_logs_match_all([


### PR DESCRIPTION
Ref: https://github.com/Shopify/krane/pull/858#issuecomment-1005896132

> Would it be OK (or even possible?) to label the test cases with both the Ruby and K8s version? It's hard to tell them apart, having only the Ruby version repeated 3 times 😄 .

@jpfourny is quite right.