### PR TITLE
Fix CI version matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
         - ruby: '2.6.8'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.18.19'
-          kind_image: '1.18: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c'
+          kind_image: 'kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c'
         - ruby: '2.6.7'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.17.17'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,24 +11,25 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-        - '3.0' # With k8s 1.23
-        - '3.0' # With k8s 1.22
-        - '3.0' # With k8s 1.21
+        # Use unique Ruby versions, or GitHub gets confused when building the rest of the matrix
+        - '3.0.3' # With k8s 1.23
+        - '3.0.2' # With k8s 1.22
+        - '3.0.1' # With k8s 1.21
         - '3.0' # With k8s 1.20
         - '2.7' # With k8s 1.19
-        - '2.6.6' # With k8s 1.18
-        - '2.6.6' # With k8s 1.17
+        - '2.6.8' # With k8s 1.18
+        - '2.6.7' # With k8s 1.17
         include:
         # Match kind images with chosen version https://github.com/kubernetes-sigs/kind/releases
-        - ruby: '3.0'
+        - ruby: '3.0.3'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.23.0'
           kind_image: 'kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac'
-        - ruby: '3.0'
+        - ruby: '3.0.2'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.22.0'
           kind_image: 'kindest/node:v1.22.0@sha256:b8bda84bb3a190e6e028b1760d277454a72267a5454b57db34437c34a588d047'
-        - ruby: '3.0'
+        - ruby: '3.0.1'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.21.1'
           kind_image: 'kindest/node:v1.21.1@sha256:69860bda5563ac81e3c0057d654b5253219618a22ec3a346306239bba8cfa1a6'
@@ -40,11 +41,11 @@ jobs:
           kind_version: 'v0.11.1'
           kubernetes_version: '1.19.11'
           kind_image: 'kindest/node:v1.19.11@sha256:07db187ae84b4b7de440a73886f008cf903fcf5764ba8106a9fd5243d6f32729'
-        - ruby: '2.6.6'
+        - ruby: '2.6.8'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.18.19'
           kind_image: '1.18: kindest/node:v1.18.19@sha256:7af1492e19b3192a79f606e43c35fb741e520d195f96399284515f077b3b622c'
-        - ruby: '2.6.6'
+        - ruby: '2.6.7'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.17.17'
           kind_image: 'kindest/node:v1.17.17@sha256:66f1d0d91a88b8a001811e2f1054af60eef3b669a9a74f9b6db871f2f1eeed00'

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -115,13 +115,8 @@ class KraneDeployTest < Krane::IntegrationTest
       prune_matcher("role", "rbac.authorization.k8s.io", "role"),
       prune_matcher("rolebinding", "rbac.authorization.k8s.io", "role-binding"),
       prune_matcher("persistentvolumeclaim", "", "hello-pv-claim"),
+      prune_matcher("ingress", %w(networking.k8s.io extensions), "web")
     ] # not necessarily listed in this order
-    # 1.21 appears to list the ingress as belonging to extensions, not networking.k8s.io
-    if kube_server_version >= Gem::Version.new("1.18.0") && kube_server_version < Gem::Version.new("1.21.0")
-      expected_pruned << prune_matcher("ingress", "networking.k8s.io", "web")
-    else
-      expected_pruned << prune_matcher("ingress", "extensions", "web")
-    end
     expected_msgs = [/Pruned 2[013] resources and successfully deployed 6 resources/]
     expected_pruned.map do |resource|
       expected_msgs << /The following resources were pruned:.*#{resource}/

--- a/test/integration_test_helper.rb
+++ b/test/integration_test_helper.rb
@@ -36,8 +36,9 @@ module Krane
       false
     end
 
-    def prune_matcher(kind, group, name)
-      kind + '(.' + group + ')?[ \/]"?' + name + '"?'
+    def prune_matcher(kind, groups, name)
+      groups = Array(groups)
+      kind + '(.' + groups.join('|.') + ')?[ \/]"?' + name + '"?'
     end
 
     def kube_client_version


### PR DESCRIPTION
Follow on #858 

The multi-dimensional matrix config in actions did not work as I expected, #859 showed that we weren't running all the kube versions we wanted. I fix it here, which reveals that some of our 1.22 and 1.23 tests are [failing](https://github.com/Shopify/krane/runs/4725641323?check_suite_focus=true#step:6:83) with `no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"`. I tried updating the version to just `v1` for all the fixture CRD's, but that [fails](https://github.com/Shopify/krane/runs/4725888565?check_suite_focus=true#step:6:879) with `missing required field "versions" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1.CustomResourceDefinitionSpec`.

Looks like the spec is different and the fixtures need more work. I'm sure someone with more context than me can help find the right fix here.
