### PR TITLE
Update kubeclient

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -27,14 +27,14 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6.0'
   spec.add_dependency("activesupport", ">= 5.0")
-  spec.add_dependency("kubeclient", "~> 4.3")
+  spec.add_dependency("kubeclient", "~> 4.9")
   spec.add_dependency("googleauth", "~> 0.8")
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
   spec.add_dependency("statsd-instrument", ['>= 2.8', "< 4"])
   spec.add_dependency("oj", "~> 3.0")
   spec.add_dependency("concurrent-ruby", "~> 1.1")
-  spec.add_dependency("jsonpath", "~> 0.9.6")
+  spec.add_dependency("jsonpath", "~> 1.0")
   spec.add_dependency("thor", ">= 1.0", "< 2.0")
 
   # Basics


### PR DESCRIPTION
Older kubeclient isn't compatible with recent psych:

```ruby
ArgumentError: wrong number of arguments (given 2, expected 1)
/app/data/bundler/ruby/2.7.0/gems/psych-4.0.2/lib/psych.rb:323:in `safe_load'
/app/data/bundler/ruby/2.7.0/gems/kubeclient-4.7.0/lib/kubeclient/config.rb:33:in `read'
```