### PR TITLE
New version with Psych compatibility fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 2.3.5
+
+- Psych 4 compatibility
+
 ## 2.3.4
 
 - Fix for [CVE-2021-41817](https://www.ruby-lang.org/en/news/2021/11/15/date-parsing-method-regexp-dos-cve-2021-41817/). See [ServicesDB action item here](https://services.shopify.io/action_items/definitions/isolated/59).

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.3.4"
+  VERSION = "2.3.5"
 end


### PR DESCRIPTION
Master branch contains some fixes that are not in the latest version, 2.3.4.
Krane 2.3.4 breaks when Psych 4.0 is installed.

```
Traceback (most recent call last):
	30: from /root/local/ruby-2.7.5/bin/krane:23:in `<main>'
	29: from /root/local/ruby-2.7.5/bin/krane:23:in `load'
	28: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/exe/krane:5:in `<top (required)>'
	27: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/thor-1.2.1/lib/thor/base.rb:485:in `start'
	26: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/thor-1.2.1/lib/thor.rb:392:in `dispatch'
	25: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/thor-1.2.1/lib/thor/invocation.rb:127:in `invoke_command'
	24: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/thor-1.2.1/lib/thor/command.rb:27:in `run'
	23: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/cli/krane.rb:27:in `render'
	22: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/cli/krane.rb:77:in `rescue_and_exit'
	21: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/cli/krane.rb:28:in `block in render'
	20: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/cli/render_command.rb:30:in `from_options'
	19: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/options_helper.rb:24:in `with_processed_template_paths'
	18: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/cli/render_command.rb:36:in `block in from_options'
	17: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/render_task.rb:46:in `run!'
	16: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/render_task.rb:60:in `render_templates'
	15: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:127:in `with_resource_definitions_and_filename'
	14: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/delayed_exceptions.rb:6:in `with_delayed_exceptions'
	13: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/delayed_exceptions.rb:6:in `each'
	12: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/delayed_exceptions.rb:8:in `block in with_delayed_exceptions'
	11: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:128:in `block in with_resource_definitions_and_filename'
	10: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:29:in `with_resource_definitions_and_filename'
	 9: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/delayed_exceptions.rb:6:in `with_delayed_exceptions'
	 8: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/delayed_exceptions.rb:6:in `each'
	 7: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/delayed_exceptions.rb:8:in `block in with_delayed_exceptions'
	 6: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:31:in `block in with_resource_definitions_and_filename'
	 5: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:88:in `templates'
	 4: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:31:in `block (2 levels) in with_resource_definitions_and_filename'
	 3: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/template_sets.rb:133:in `block (2 levels) in with_resource_definitions_and_filename'
	 2: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/render_task.rb:62:in `block in render_templates'
	 1: from /root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/krane-2.3.4/lib/krane/render_task.rb:76:in `write_to_stream'
/root/local/ruby-2.7.5/lib/ruby/gems/2.7.0/gems/psych-4.0.2/lib/psych.rb:452:in `parse_stream': wrong number of arguments (given 2, expected 1) (ArgumentError)
```