### PR TITLE
update README.md to state Ruby 2.7+ is a prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you need the ability to render dynamic values in templates before deploying, 
 
 ## Prerequisites
 
-* Ruby 2.6+
+* Ruby 2.7+
 * Your cluster must be running Kubernetes v1.19.0 or higher<sup>1</sup>
 
 <sup>1</sup> We run integration tests against these Kubernetes versions. You can find our


### PR DESCRIPTION
update README.md to state Ruby 2.7+ is a prerequisite