### PR TITLE
`krane render`: render templates in deterministic order

### DIFF
--- a/lib/krane/template_sets.rb
+++ b/lib/krane/template_sets.rb
@@ -104,7 +104,7 @@ module Krane
         dir_paths.each do |template_dir|
           resource_templates[template_dir] = Dir.foreach(template_dir).select do |filename|
             filename.end_with?(*VALID_TEMPLATES) || filename == EjsonSecretProvisioner::EJSON_SECRETS_FILE
-          end
+          end.sort
         end
 
         # Filename paths

--- a/lib/krane/template_sets.rb
+++ b/lib/krane/template_sets.rb
@@ -108,7 +108,7 @@ module Krane
         end
 
         # Filename paths
-        file_paths.each do |filename|
+        file_paths.sort.each do |filename|
           dir_name = File.dirname(filename)
           resource_templates[dir_name] ||= []
           resource_templates[dir_name] << File.basename(filename) unless resource_templates[dir_name].include?(filename)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
I'm using `krane render -f some.yaml.erb > fixtures/some.yaml.lock` in my (private) repo to produce a set of "fixtures", so I know the full yaml generated by our ERBs and partials, and can clearly diff how a partial change will affect multiple different deployments.

Right now, `krane render` can produce different outputs on MacOS versus linux, based on the order of filenames returned by [`Dir.foreach`](https://ruby-doc.org/core-2.7.5/Dir.html#method-c-foreach). This causes the fixtures generated on my Mac to differ from the fixtures expected in CI on linux, causing CI to fail. I want to render templates in a deterministic order.

**How is this accomplished?**
If I `.sort` the output of `Dir.foreach`, it renders files in the same order on any OS. For completeness, I'm also sorting `file_paths`.

**What could go wrong?**
This only impacts the order of template generation, so it _shouldn't_ impact the order that resources are actually deployed. Still there could be unexpected consequences that I'm not aware of. 
