### PR TITLE
[Bug Fix] Grouping Cluster Resources by group and Kind

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -240,9 +240,7 @@ module Krane
       resources = []
       crds_by_group_kind = cluster_resource_discoverer.crds.group_by(&:group_kind)
       @template_sets.with_resource_definitions(current_sha: @current_sha, bindings: @bindings) do |r_def|
-        grouping, version = r_def.dig("apiVersion").split("/")
-        group = version ? grouping : "core"
-        kind = r_def["kind"] ? r_def["kind"] : ""
+        group, kind = group_kind_for_r_def(r_def)
         crd = crds_by_group_kind[group + "/" + kind]&.first
         r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,
           statsd_tags: @namespace_tags, crd: crd, global_names: @task_config.global_kinds)
@@ -392,5 +390,12 @@ module Krane
         retried += 1
       end
     end
+
+    def group_kind_for_r_def(r_def)
+      grouping, version = r_def.dig("apiVersion").split("/")
+      group = version ? grouping : "core"
+      kind = r_def["kind"].to_s
+      [group, kind]
+    end  
   end
 end

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -238,9 +238,10 @@ module Krane
     def discover_resources
       @logger.info("Discovering resources:")
       resources = []
-      crds_by_kind = cluster_resource_discoverer.crds.group_by(&:kind)
+      crds_by_group_kind = cluster_resource_discoverer.crds.group_by(&:group_kind)
       @template_sets.with_resource_definitions(current_sha: @current_sha, bindings: @bindings) do |r_def|
-        crd = crds_by_kind[r_def["kind"]]&.first
+        group = r_def.dig("apiVersion").split("/").first
+        crd = crds_by_group_kind[group + "/" + r_def["kind"]]&.first
         r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,
           statsd_tags: @namespace_tags, crd: crd, global_names: @task_config.global_kinds)
         resources << r

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -74,7 +74,7 @@ module Krane
         Pod
       ).map { |r| [r, default_group] }
 
-      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.kind, { group: cr.group }] }
+      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.group_kind, { group: cr.group }] }
       Hash[before_crs + crs + after_crs]
     end
 
@@ -241,7 +241,7 @@ module Krane
       crds_by_group_kind = cluster_resource_discoverer.crds.group_by(&:group_kind)
       @template_sets.with_resource_definitions(current_sha: @current_sha, bindings: @bindings) do |r_def|
         group, kind = group_kind_for_r_def(r_def)
-        crd = crds_by_group_kind[group + "/" + kind]&.first
+        crd = crds_by_group_kind["#{kind}.#{group}"]&.first
         r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,
           statsd_tags: @namespace_tags, crd: crd, global_names: @task_config.global_kinds)
         resources << r
@@ -396,6 +396,6 @@ module Krane
       group = version ? grouping : "core"
       kind = r_def["kind"].to_s
       [group, kind]
-    end  
+    end
   end
 end

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -240,8 +240,10 @@ module Krane
       resources = []
       crds_by_group_kind = cluster_resource_discoverer.crds.group_by(&:group_kind)
       @template_sets.with_resource_definitions(current_sha: @current_sha, bindings: @bindings) do |r_def|
-        group = r_def.dig("apiVersion").split("/").first
-        crd = crds_by_group_kind[group + "/" + r_def["kind"]]&.first
+        grouping, version = r_def.dig("apiVersion").split("/")
+        group = version ? grouping : "core"
+        kind = r_def["kind"] ? r_def["kind"] : ""
+        crd = crds_by_group_kind[group + "/" + kind]&.first
         r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,
           statsd_tags: @namespace_tags, crd: crd, global_names: @task_config.global_kinds)
         resources << r

--- a/lib/krane/kubernetes_resource/custom_resource.rb
+++ b/lib/krane/kubernetes_resource/custom_resource.rb
@@ -59,7 +59,7 @@ module Krane
     end
 
     def type
-      kind
+      group_kind
     end
 
     def validate_definition(*, **)
@@ -77,7 +77,11 @@ module Krane
     private
 
     def kind
-      @definition["kind"]
+      @crd.kind
+    end
+
+    def group_kind
+      @crd.group_kind
     end
 
     def rollout_conditions

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -41,12 +41,10 @@ module Krane
       # New spec here: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition
       # This is only used in testing, so we will simply take the first version we see:
       version = @definition.dig("spec", "versions", 0, "name")
-      kind = @definition.dig("spec", "names", "kind")
       "#{group}/#{version}/#{kind}"
     end
 
     def group_kind
-      kind = @definition.dig("spec", "names", "kind")
       group = @definition.dig("spec", "group")
       "#{group}/#{kind}"
     end

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -44,17 +44,16 @@ module Krane
       "#{group}/#{version}/#{kind}"
     end
 
-    def group_kind
-      group = @definition.dig("spec", "group")
-      "#{group}/#{kind}"
-    end
-
     def kind
       @definition.dig("spec", "names", "kind")
     end
 
     def group
       @definition.dig("spec", "group")
+    end
+
+    def group_kind
+      "#{kind}.#{group}"
     end
 
     def prunable?

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -41,7 +41,14 @@ module Krane
       # New spec here: https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#create-a-customresourcedefinition
       # This is only used in testing, so we will simply take the first version we see:
       version = @definition.dig("spec", "versions", 0, "name")
+      kind = @definition.dig("spec", "names", "kind")
       "#{group}/#{version}/#{kind}"
+    end
+
+    def group_kind
+      kind = @definition.dig("spec", "names", "kind")
+      group = @definition.dig("spec", "group")
+      "#{group}/#{kind}"
     end
 
     def kind

--- a/test/fixtures/crd/for_group_kind_test.yml
+++ b/test/fixtures/crd/for_group_kind_test.yml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     krane.shopify.io/instance-rollout-conditions: "true"
 spec:
-  group: will-rollout-conditions.example.io
+  group: with-rollout-conditions.example.io
   names:
     kind: SameKind
     listKind: SameKindList
@@ -25,6 +25,25 @@ spec:
           properties:
             spec:
               type: object
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/test/fixtures/crd/for_group_kind_test.yml
+++ b/test/fixtures/crd/for_group_kind_test.yml
@@ -1,0 +1,52 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: same-kinds.with-rollout-conditions.example.io
+  labels:
+    app: krane
+  annotations:
+    krane.shopify.io/instance-rollout-conditions: "true"
+spec:
+  group: will-rollout-conditions.example.io
+  names:
+    kind: SameKind
+    listKind: SameKindList
+    plural: same-kinds
+    singular: same-kind
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: same-kinds.no-rollout-conditions.example.io
+  labels:
+    app: krane
+spec:
+  group: no-rollout-conditions.example.io
+  names:
+    kind: SameKind
+    listKind: SameKindList
+    plural: same-kinds
+    singular: same-kind
+  scope: Namespaced
+  versions:
+    - name: v1
+      served: true
+      storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              type: object

--- a/test/fixtures/crd/for_group_kind_test_cr.yml
+++ b/test/fixtures/crd/for_group_kind_test_cr.yml
@@ -1,0 +1,10 @@
+---
+apiVersion: "with-rollout-conditions.example.io"
+kind: SameKind
+metadata:
+  name: monitored
+---
+apiVersion: "no-rollout-conditions.example.io"
+kind: SameKind
+metadata:
+  name: monitored

--- a/test/fixtures/crd/for_group_kind_test_cr.yml
+++ b/test/fixtures/crd/for_group_kind_test_cr.yml
@@ -1,10 +1,10 @@
 ---
-apiVersion: "with-rollout-conditions.example.io"
+apiVersion: "with-rollout-conditions.example.io/v1"
 kind: SameKind
 metadata:
   name: monitored
 ---
-apiVersion: "no-rollout-conditions.example.io"
+apiVersion: "no-rollout-conditions.example.io/v1"
 kind: SameKind
 metadata:
-  name: monitored
+  name: unmonitored

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -30,8 +30,8 @@ module FixtureSetAssertions
     def refute_resource_exists(type, name)
       client = if %w(daemonset deployment replicaset statefulset).include?(type)
         apps_v1_kubeclient
-     elsif %w(ingress networkpolicy).include?(type)
-       networking_v1_kubeclient
+      elsif %w(ingress networkpolicy).include?(type)
+        networking_v1_kubeclient
       else
         kubeclient
       end
@@ -96,12 +96,16 @@ module FixtureSetAssertions
     end
 
     def assert_ingress_up(ing_name)
-      ing = networking_v1_kubeclient.get_ingresses(namespace: namespace, label_selector: "name=#{ing_name},app=#{app_name}")
+      ing = networking_v1_kubeclient.get_ingresses(
+        namespace: namespace, label_selector: "name=#{ing_name},app=#{app_name}"
+      )
       assert_equal(1, ing.size, "Expected 1 #{ing_name} ingress, got #{ing.size}")
     end
 
     def assert_configmap_present(cm_name, expected_data)
-      configmaps = kubeclient.get_config_maps(namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}")
+      configmaps = kubeclient.get_config_maps(
+        namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}"
+      )
       assert_equal(1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}")
       assert_equal(expected_data, configmaps.first["data"].to_h)
     end

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -380,25 +380,11 @@ class SerialDeployTest < Krane::IntegrationTest
     ], in_order: true)
   end
 
-  # Make 2 CRDs
-  # foo.bar same-kind
-  # baz.bat same-kind
-
-  # foo.bar/same-kind has rollout-conditions
-  # baz.bat/same-kind does not
-
-  # Step 1: deploy CRDs
-  # Step 2: deploy 2 CRs, one of each group/kind
-
-  # We expect to see in the logs:
-  # Don't know how to monitor type of #{unmonitored_kind}
-
-  # We expect to NOT SEE in the logs:
-  # Don't konw how to monitor type of #{monitored_kind}
-
+ 
+  # Make 2 CRDs of same kind, different group. We expect the appropriate one to be monitored and
+  # the other to be unmonitored for rollout conditions
   def test_cr_references_parent_crd_by_group_kind
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(for_group_kind_test.yml)))
-
     success_conditions = {
       "status" => {
         "observedGeneration" => 1,

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -40,20 +40,22 @@ class KraneDeployTest < Krane::IntegrationTest
     assert_deploy_failure(deploy_raw_fixtures("empty-resources", subset: %w[empty1.yml empty2.yml]))
 
     assert_logs_match_all([
-                            "All required parameters and files are present",
-                            "Result: FAILURE",
-                            "No deployable resources were found!",
-                          ], in_order: true)
+      "All required parameters and files are present",
+      "Result: FAILURE",
+      "No deployable resources were found!",
+    ], in_order: true)
   end
 
   def test_deploy_fails_with_empty_erb
-    assert_deploy_failure(deploy_raw_fixtures("empty-resources", subset: %w[empty3.yml.erb empty4.yml.erb], render_erb: true))
+    assert_deploy_failure(
+      deploy_raw_fixtures("empty-resources", subset: %w[empty3.yml.erb empty4.yml.erb], render_erb: true)
+    )
 
     assert_logs_match_all([
-                            "All required parameters and files are present",
-                            "Result: FAILURE",
-                            "No deployable resources were found!",
-                          ], in_order: true)
+      "All required parameters and files are present",
+      "Result: FAILURE",
+      "No deployable resources were found!",
+    ], in_order: true)
   end
 
   def test_service_account_predeployed_before_unmanaged_pod
@@ -135,7 +137,7 @@ class KraneDeployTest < Krane::IntegrationTest
       prune_matcher("role", "rbac.authorization.k8s.io", "role"),
       prune_matcher("rolebinding", "rbac.authorization.k8s.io", "role-binding"),
       prune_matcher("persistentvolumeclaim", "", "hello-pv-claim"),
-      prune_matcher("ingress", %w(networking.k8s.io extensions), "web")
+      prune_matcher("ingress", %w(networking.k8s.io extensions), "web"),
     ] # not necessarily listed in this order
     expected_msgs = [/Pruned 2[013] resources and successfully deployed 6 resources/]
     expected_pruned.map do |resource|

--- a/test/unit/krane/kubernetes_resource/custom_resource_definition_test.rb
+++ b/test/unit/krane/kubernetes_resource/custom_resource_definition_test.rb
@@ -96,6 +96,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: @statsd_tags, crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => { "name" => "test" },
       })
     cr.validate_definition(kubectl: kubectl)
@@ -129,6 +130,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => { "name" => "test" },
       })
     cr.validate_definition(kubectl: kubectl)
@@ -154,7 +156,11 @@ class CustomResourceDefinitionTest < Krane::TestCase
     ))
     cr = Krane::KubernetesResource.build(namespace: "test", context: "test",
       logger: @logger, statsd_tags: [], crd: crd,
-      definition: { "kind" => "UnitTest", "metadata" => { "name" => "test" } })
+      definition: {
+        "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
+        "metadata" => { "name" => "test" },
+      })
     assert_equal(cr.timeout, 60)
   end
 
@@ -171,6 +177,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => {
           "name" => "test",
         },
@@ -195,6 +202,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => {
           "name" => "test",
         },

--- a/test/unit/resource_cache_test.rb
+++ b/test/unit/resource_cache_test.rb
@@ -125,12 +125,13 @@ class ResourceCacheTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => {
           "name" => "test",
         },
       })
 
-    stub_kind_get("UnitTest", times: 1)
+    stub_kind_get("UnitTest.stable.example.io", times: 1)
     stub_kind_get("CustomResourceDefinition", times: 1)
     resources = [cr, crd]
     @cache.prewarm(resources)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fixes [#873](https://github.com/Shopify/krane/issues/873)

**How is this accomplished?**
Instead of grouping by `kind` in `DeployTask#discover_resources`, we now group by `group` and `kind` to avoid picking the wrong CRD when there are duplicates of the same `kind`. 

**What could go wrong?**
...
