### PR TITLE
version 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## next
 
+## 2.4.2
+
 *Bug fixes*
 
+- Resolve errors for StatefulSet restart with `updateStrategy: OnDelete` [#876](https://github.com/Shopify/krane/pull/876)
 - Timeouts during the "predeploy priority resources" phase now raise `DeploymentTimeoutError` instead of `FatalDeploymentError` [#874](https://github.com/Shopify/krane/pull/874)
 
 ## 2.4.1

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.4.1"
+  VERSION = "2.4.2"
 end


### PR DESCRIPTION
Release includes:

- Resolve errors for StatefulSet restart with `updateStrategy: OnDelete` [#876](https://github.com/Shopify/krane/pull/876)
- Timeouts during the "predeploy priority resources" phase now raise `DeploymentTimeoutError` instead of `FatalDeploymentError` [#874](https://github.com/Shopify/krane/pull/874)