### PR TITLE
Add support for required-rollout annotation on DaemonSets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ If you want dynamic templates, you may render ERB with `krane render` and then p
   - _Compatibility_: all resource types
 - `krane.shopify.io/required-rollout`: Modifies how much of the rollout needs to finish
 before the deployment is considered successful.
-  - _Compatibility_: Deployment
+  - _Compatibility_: Deployment, DaemonSet
   - `full`: The deployment is successful when all pods in the new `replicaSet` are ready.
   - `none`: The deployment is successful as soon as the new `replicaSet` is created for the deployment.
   - `maxUnavailable`: The deploy is successful when minimum availability is reached in the new `replicaSet`.


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Adding support for `krane.shopify.io/required-rollout` annotation on `DaemonSets` resources.

This features is already available for Deployment.

**How is this accomplished?**
...

**What could go wrong?**
...
