### PR TITLE
Cr group kind fixes

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -74,7 +74,7 @@ module Krane
         Pod
       ).map { |r| [r, default_group] }
 
-      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.kind, { group: cr.group }] }
+      crs = cluster_resource_discoverer.crds.select(&:predeployed?).map { |cr| [cr.group_kind, { group: cr.group }] }
       Hash[before_crs + crs + after_crs]
     end
 
@@ -241,7 +241,7 @@ module Krane
       crds_by_group_kind = cluster_resource_discoverer.crds.group_by(&:group_kind)
       @template_sets.with_resource_definitions(current_sha: @current_sha, bindings: @bindings) do |r_def|
         group, kind = group_kind_for_r_def(r_def)
-        crd = crds_by_group_kind[group + "/" + kind]&.first
+        crd = crds_by_group_kind["#{kind}.#{group}"]&.first
         r = KubernetesResource.build(namespace: @namespace, context: @context, logger: @logger, definition: r_def,
           statsd_tags: @namespace_tags, crd: crd, global_names: @task_config.global_kinds)
         resources << r
@@ -396,6 +396,6 @@ module Krane
       group = version ? grouping : "core"
       kind = r_def["kind"].to_s
       [group, kind]
-    end  
+    end
   end
 end

--- a/lib/krane/kubernetes_resource/custom_resource.rb
+++ b/lib/krane/kubernetes_resource/custom_resource.rb
@@ -59,7 +59,7 @@ module Krane
     end
 
     def type
-      kind
+      group_kind
     end
 
     def validate_definition(*, **)
@@ -77,7 +77,11 @@ module Krane
     private
 
     def kind
-      @definition["kind"]
+      @crd.kind
+    end
+
+    def group_kind
+      @crd.group_kind
     end
 
     def rollout_conditions

--- a/lib/krane/kubernetes_resource/custom_resource_definition.rb
+++ b/lib/krane/kubernetes_resource/custom_resource_definition.rb
@@ -44,17 +44,16 @@ module Krane
       "#{group}/#{version}/#{kind}"
     end
 
-    def group_kind
-      group = @definition.dig("spec", "group")
-      "#{group}/#{kind}"
-    end
-
     def kind
       @definition.dig("spec", "names", "kind")
     end
 
     def group
       @definition.dig("spec", "group")
+    end
+
+    def group_kind
+      "#{kind}.#{group}"
     end
 
     def prunable?

--- a/test/fixtures/crd/for_group_kind_test.yml
+++ b/test/fixtures/crd/for_group_kind_test.yml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     krane.shopify.io/instance-rollout-conditions: "true"
 spec:
-  group: will-rollout-conditions.example.io
+  group: with-rollout-conditions.example.io
   names:
     kind: SameKind
     listKind: SameKindList
@@ -25,6 +25,25 @@ spec:
           properties:
             spec:
               type: object
+            status:
+              type: object
+              properties:
+                observedGeneration:
+                  type: integer
+                conditions:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      type:
+                        type: string
+                      reason:
+                        type: string
+                      message:
+                        type: string
+                      status:
+                        type: string
+
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition

--- a/test/fixtures/crd/for_group_kind_test_cr.yml
+++ b/test/fixtures/crd/for_group_kind_test_cr.yml
@@ -1,10 +1,10 @@
 ---
-apiVersion: "with-rollout-conditions.example.io"
+apiVersion: "with-rollout-conditions.example.io/v1"
 kind: SameKind
 metadata:
   name: monitored
 ---
-apiVersion: "no-rollout-conditions.example.io"
+apiVersion: "no-rollout-conditions.example.io/v1"
 kind: SameKind
 metadata:
-  name: monitored
+  name: unmonitored

--- a/test/helpers/fixture_set.rb
+++ b/test/helpers/fixture_set.rb
@@ -30,8 +30,8 @@ module FixtureSetAssertions
     def refute_resource_exists(type, name)
       client = if %w(daemonset deployment replicaset statefulset).include?(type)
         apps_v1_kubeclient
-     elsif %w(ingress networkpolicy).include?(type)
-       networking_v1_kubeclient
+      elsif %w(ingress networkpolicy).include?(type)
+        networking_v1_kubeclient
       else
         kubeclient
       end
@@ -96,12 +96,16 @@ module FixtureSetAssertions
     end
 
     def assert_ingress_up(ing_name)
-      ing = networking_v1_kubeclient.get_ingresses(namespace: namespace, label_selector: "name=#{ing_name},app=#{app_name}")
+      ing = networking_v1_kubeclient.get_ingresses(
+        namespace: namespace, label_selector: "name=#{ing_name},app=#{app_name}"
+      )
       assert_equal(1, ing.size, "Expected 1 #{ing_name} ingress, got #{ing.size}")
     end
 
     def assert_configmap_present(cm_name, expected_data)
-      configmaps = kubeclient.get_config_maps(namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}")
+      configmaps = kubeclient.get_config_maps(
+        namespace: namespace, label_selector: "name=#{cm_name},app=#{app_name}"
+      )
       assert_equal(1, configmaps.size, "Expected 1 configmap, got #{configmaps.size}")
       assert_equal(expected_data, configmaps.first["data"].to_h)
     end

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -408,12 +408,11 @@ class SerialDeployTest < Krane::IntegrationTest
       unmonitored["kind"] = add_unique_prefix_for_test(unmonitored["kind"])
     end
     assert_deploy_success(result)
+    prefixed_kind = add_unique_prefix_for_test("SameKind")
     assert_logs_match_all([
-      %r{Successfully deployed in .*:
-        #{add_unique_prefix_for_test("SameKind")}.no-rollout-conditions.example.io/unmonitored,
-        #{add_unique_prefix_for_test("SameKind")}.with-rollout-conditions.example.io/monitored},
-      %r{#{add_unique_prefix_for_test("SameKind")}.no-rollout-conditions.example.io/unmonitored Exists},
-      %r{#{add_unique_prefix_for_test("SameKind")}.with-rollout-conditions.example.io/monitored Healthy},
+      /Successfully deployed in .*: /,
+      %r{#{prefixed_kind}.no-rollout-conditions.example.io/unmonitored Exists},
+      %r{#{prefixed_kind}.with-rollout-conditions.example.io/monitored Healthy},
     ])
   end
 

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -265,9 +265,9 @@ class SerialDeployTest < Krane::IntegrationTest
     end
     assert_deploy_success(result)
 
-    mail_cr_id = "#{add_unique_prefix_for_test('Mail')}/my-first-mail"
-    thing_cr_id = "#{add_unique_prefix_for_test('Thing')}/my-first-thing"
-    widget_cr_id = "#{add_unique_prefix_for_test('Widget')}/my-first-widget"
+    mail_cr_id = "#{add_unique_prefix_for_test('Mail')}.stable.example.io/my-first-mail"
+    thing_cr_id = "#{add_unique_prefix_for_test('Thing')}.stable.example.io/my-first-thing"
+    widget_cr_id = "#{add_unique_prefix_for_test('Widget')}.stable.example.io/my-first-widget"
     assert_logs_match_all([
       /Phase 3: Predeploying priority resources/,
       /Successfully deployed in \d.\ds: #{mail_cr_id}/,
@@ -291,11 +291,11 @@ class SerialDeployTest < Krane::IntegrationTest
     end
 
     assert_deploy_success(result)
-    prefixed_kind = add_unique_prefix_for_test("Widget")
+    prefixed_kind = "#{add_unique_prefix_for_test('Widget')}.stable.example.io"
     assert_logs_match_all([
       "Don't know how to monitor resources of type #{prefixed_kind}.",
       "Assuming #{prefixed_kind}/my-first-widget deployed successfully.",
-      %r{Widget/my-first-widget\s+Exists},
+      %r{#{prefixed_kind}/my-first-widget\s+Exists},
     ])
   end
 
@@ -320,10 +320,11 @@ class SerialDeployTest < Krane::IntegrationTest
       cr.merge!(success_conditions)
       cr["kind"] = add_unique_prefix_for_test(cr["kind"])
     end
+    prefixed_name = "#{add_unique_prefix_for_test('Parameterized')}.stable.example.io"
     assert_deploy_success(result)
     assert_logs_match_all([
-      %r{Successfully deployed in .*: #{add_unique_prefix_for_test("Parameterized")}\/with-default-params},
-      %r{Parameterized/with-default-params\s+Healthy},
+      %r{Successfully deployed in .*: #{prefixed_name}\/with-default-params},
+      %r{Parameterized.stable.example.io/with-default-params\s+Healthy},
     ])
   end
 
@@ -374,15 +375,14 @@ class SerialDeployTest < Krane::IntegrationTest
     assert_deploy_failure(result)
 
     assert_logs_match_all([
-      "Parameterized/with-default-params: FAILED",
+      "Parameterized.stable.example.io/with-default-params: FAILED",
       "custom resource rollout failed",
       "Final status: Unhealthy",
     ], in_order: true)
   end
 
- 
-  # Make 2 CRDs of same kind, different group. We expect the appropriate one to be monitored and
-  # the other to be unmonitored for rollout conditions
+  # # Make 2 CRDs of same kind, different group. We expect the appropriate one to be monitored and
+  # # the other to be unmonitored for rollout conditions
   def test_cr_references_parent_crd_by_group_kind
     assert_deploy_success(deploy_global_fixtures("crd", subset: %(for_group_kind_test.yml)))
     success_conditions = {
@@ -400,13 +400,20 @@ class SerialDeployTest < Krane::IntegrationTest
     }
 
     result = deploy_fixtures("crd", subset: %(for_group_kind_test_cr.yml)) do |resource|
-      cr = resource["for_group_kind_test_cr.yml"]["SameKind"].first
-      cr["kind"] = add_unique_prefix_for_test(cr["kind"])
-      cr.merge!(success_conditions)
+      monitored = resource["for_group_kind_test_cr.yml"]["SameKind"][0]
+      monitored["kind"] = add_unique_prefix_for_test(monitored["kind"])
+      monitored.merge!(success_conditions)
+
+      unmonitored = resource["for_group_kind_test_cr.yml"]["SameKind"][1]
+      unmonitored["kind"] = add_unique_prefix_for_test(unmonitored["kind"])
     end
     assert_deploy_success(result)
     assert_logs_match_all([
-      %r{Successfully deployed   in .*: #{add_unique_prefix_for_test("SameKind")}\/monitored},
+      %r{Successfully deployed in .*:
+        #{add_unique_prefix_for_test("SameKind")}.no-rollout-conditions.example.io/unmonitored,
+        #{add_unique_prefix_for_test("SameKind")}.with-rollout-conditions.example.io/monitored},
+      %r{#{add_unique_prefix_for_test("SameKind")}.no-rollout-conditions.example.io/unmonitored Exists},
+      %r{#{add_unique_prefix_for_test("SameKind")}.with-rollout-conditions.example.io/monitored Healthy},
     ])
   end
 
@@ -428,8 +435,9 @@ class SerialDeployTest < Krane::IntegrationTest
       cr.merge!(success_conditions)
     end
     assert_deploy_success(result)
+    prefixed_name = "#{add_unique_prefix_for_test('Customized')}.stable.example.io"
     assert_logs_match_all([
-      %r{Successfully deployed in .*: #{add_unique_prefix_for_test("Customized")}\/with-customized-params},
+      %r{Successfully deployed in .*: #{prefixed_name}\/with-customized-params},
     ])
   end
 
@@ -480,7 +488,7 @@ class SerialDeployTest < Krane::IntegrationTest
       end
     end
     assert_deploy_failure(result)
-    prefixed_name = add_unique_prefix_for_test("Customized-with-customized-params")
+    prefixed_name = add_unique_prefix_for_test('Customized.stable.example.io-with-customized-params').to_s
     assert_logs_match_all([
       /Invalid template: #{prefixed_name}/,
       /Rollout conditions are not valid JSON/,

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -1,4 +1,3 @@
-frozen_string_literal: true
 # frozen_string_literal: true
 require 'integration_test_helper'
 

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -1,85 +1,85 @@
+frozen_string_literal: true
 # frozen_string_literal: true
-# # frozen_string_literal: true
-# require 'integration_test_helper'
+require 'integration_test_helper'
 
-# class SerialTaskRunTest < Krane::IntegrationTest
-#   include TaskRunnerTestHelper
-#   include StatsD::Instrument::Assertions
+class SerialTaskRunTest < Krane::IntegrationTest
+  include TaskRunnerTestHelper
+  include StatsD::Instrument::Assertions
 
-#   # Mocha is not thread-safe: https://github.com/freerange/mocha#thread-safety
-#   def test_run_without_verify_result_fails_if_pod_was_not_created
-#     deploy_task_template
-#     task_runner = build_task_runner
+  # Mocha is not thread-safe: https://github.com/freerange/mocha#thread-safety
+  def test_run_without_verify_result_fails_if_pod_was_not_created
+    deploy_task_template
+    task_runner = build_task_runner
 
-#     # Sketchy, but stubbing the kubeclient doesn't work (and wouldn't be concurrency-friendly)
-#     # Finding a way to reliably trigger a create failure would be much better, if possible
-#     mock = mock()
-#     template = kubeclient.get_pod_template('hello-cloud-template-runner', @namespace)
-#     mock.expects(:get_pod_template).returns(template)
-#     mock.expects(:create_pod).raises(Kubeclient::HttpError.new("409", "Pod with same name exists", {}))
-#     task_runner.instance_variable_set(:@kubeclient, mock)
+    # Sketchy, but stubbing the kubeclient doesn't work (and wouldn't be concurrency-friendly)
+    # Finding a way to reliably trigger a create failure would be much better, if possible
+    mock = mock()
+    template = kubeclient.get_pod_template('hello-cloud-template-runner', @namespace)
+    mock.expects(:get_pod_template).returns(template)
+    mock.expects(:create_pod).raises(Kubeclient::HttpError.new("409", "Pod with same name exists", {}))
+    task_runner.instance_variable_set(:@kubeclient, mock)
 
-#     result = task_runner.run(**run_params(verify_result: false))
-#     assert_task_run_failure(result)
+    result = task_runner.run(**run_params(verify_result: false))
+    assert_task_run_failure(result)
 
-#     assert_logs_match_all([
-#       "Running pod",
-#       "Result: FAILURE",
-#       "Failed to create pod",
-#       "Kubeclient::HttpError: Pod with same name exists",
-#     ], in_order: true)
-#   end
+    assert_logs_match_all([
+      "Running pod",
+      "Result: FAILURE",
+      "Failed to create pod",
+      "Kubeclient::HttpError: Pod with same name exists",
+    ], in_order: true)
+  end
 
-#   # Run statsd tests in serial because capture_statsd_calls modifies global state in a way
-#   # that makes capturing metrics across parallel runs unreliable
-#   def test_failure_statsd_metric_emitted
-#     bad_ns = "missing"
-#     task_runner = build_task_runner(ns: bad_ns)
+  # Run statsd tests in serial because capture_statsd_calls modifies global state in a way
+  # that makes capturing metrics across parallel runs unreliable
+  def test_failure_statsd_metric_emitted
+    bad_ns = "missing"
+    task_runner = build_task_runner(ns: bad_ns)
 
-#     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-#       result = task_runner.run(**run_params)
-#       assert_task_run_failure(result)
-#     end
+    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+      result = task_runner.run(**run_params)
+      assert_task_run_failure(result)
+    end
 
-#     metric = metrics.find do |m|
-#       m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
-#     end
-#     assert(metric, "No result metric found for this test")
-#     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
-#     assert_includes(metric.tags, "status:failure")
-#   end
+    metric = metrics.find do |m|
+      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
+    end
+    assert(metric, "No result metric found for this test")
+    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+    assert_includes(metric.tags, "status:failure")
+  end
 
-#   def test_success_statsd_metric_emitted
-#     deploy_task_template
-#     task_runner = build_task_runner
+  def test_success_statsd_metric_emitted
+    deploy_task_template
+    task_runner = build_task_runner
 
-#     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-#       result = task_runner.run(**run_params.merge(verify_result: false))
-#       assert_task_run_success(result)
-#     end
+    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+      result = task_runner.run(**run_params.merge(verify_result: false))
+      assert_task_run_success(result)
+    end
 
-#     metric = metrics.find do |m|
-#       m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
-#     end
-#     assert(metric, "No result metric found for this test")
-#     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
-#     assert_includes(metric.tags, "status:success")
-#   end
+    metric = metrics.find do |m|
+      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
+    end
+    assert(metric, "No result metric found for this test")
+    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+    assert_includes(metric.tags, "status:success")
+  end
 
-#   def test_timedout_statsd_metric_emitted
-#     deploy_task_template
-#     task_runner = build_task_runner(global_timeout: 0)
+  def test_timedout_statsd_metric_emitted
+    deploy_task_template
+    task_runner = build_task_runner(global_timeout: 0)
 
-#     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-#       result = task_runner.run(**run_params.merge(arguments: ["sleep 5"]))
-#       assert_task_run_failure(result, :timed_out)
-#     end
+    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+      result = task_runner.run(**run_params.merge(arguments: ["sleep 5"]))
+      assert_task_run_failure(result, :timed_out)
+    end
 
-#     metric = metrics.find do |m|
-#       m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
-#     end
-#     assert(metric, "No result metric found for this test")
-#     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
-#     assert_includes(metric.tags, "status:timeout")
-#   end
+    metric = metrics.find do |m|
+      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
+    end
+    assert(metric, "No result metric found for this test")
+    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+    assert_includes(metric.tags, "status:timeout")
+  end
 # end

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -1,84 +1,85 @@
 # frozen_string_literal: true
-require 'integration_test_helper'
+# # frozen_string_literal: true
+# require 'integration_test_helper'
 
-class SerialTaskRunTest < Krane::IntegrationTest
-  include TaskRunnerTestHelper
-  include StatsD::Instrument::Assertions
+# class SerialTaskRunTest < Krane::IntegrationTest
+#   include TaskRunnerTestHelper
+#   include StatsD::Instrument::Assertions
 
-  # Mocha is not thread-safe: https://github.com/freerange/mocha#thread-safety
-  def test_run_without_verify_result_fails_if_pod_was_not_created
-    deploy_task_template
-    task_runner = build_task_runner
+#   # Mocha is not thread-safe: https://github.com/freerange/mocha#thread-safety
+#   def test_run_without_verify_result_fails_if_pod_was_not_created
+#     deploy_task_template
+#     task_runner = build_task_runner
 
-    # Sketchy, but stubbing the kubeclient doesn't work (and wouldn't be concurrency-friendly)
-    # Finding a way to reliably trigger a create failure would be much better, if possible
-    mock = mock()
-    template = kubeclient.get_pod_template('hello-cloud-template-runner', @namespace)
-    mock.expects(:get_pod_template).returns(template)
-    mock.expects(:create_pod).raises(Kubeclient::HttpError.new("409", "Pod with same name exists", {}))
-    task_runner.instance_variable_set(:@kubeclient, mock)
+#     # Sketchy, but stubbing the kubeclient doesn't work (and wouldn't be concurrency-friendly)
+#     # Finding a way to reliably trigger a create failure would be much better, if possible
+#     mock = mock()
+#     template = kubeclient.get_pod_template('hello-cloud-template-runner', @namespace)
+#     mock.expects(:get_pod_template).returns(template)
+#     mock.expects(:create_pod).raises(Kubeclient::HttpError.new("409", "Pod with same name exists", {}))
+#     task_runner.instance_variable_set(:@kubeclient, mock)
 
-    result = task_runner.run(**run_params(verify_result: false))
-    assert_task_run_failure(result)
+#     result = task_runner.run(**run_params(verify_result: false))
+#     assert_task_run_failure(result)
 
-    assert_logs_match_all([
-      "Running pod",
-      "Result: FAILURE",
-      "Failed to create pod",
-      "Kubeclient::HttpError: Pod with same name exists",
-    ], in_order: true)
-  end
+#     assert_logs_match_all([
+#       "Running pod",
+#       "Result: FAILURE",
+#       "Failed to create pod",
+#       "Kubeclient::HttpError: Pod with same name exists",
+#     ], in_order: true)
+#   end
 
-  # Run statsd tests in serial because capture_statsd_calls modifies global state in a way
-  # that makes capturing metrics across parallel runs unreliable
-  def test_failure_statsd_metric_emitted
-    bad_ns = "missing"
-    task_runner = build_task_runner(ns: bad_ns)
+#   # Run statsd tests in serial because capture_statsd_calls modifies global state in a way
+#   # that makes capturing metrics across parallel runs unreliable
+#   def test_failure_statsd_metric_emitted
+#     bad_ns = "missing"
+#     task_runner = build_task_runner(ns: bad_ns)
 
-    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(**run_params)
-      assert_task_run_failure(result)
-    end
+#     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+#       result = task_runner.run(**run_params)
+#       assert_task_run_failure(result)
+#     end
 
-    metric = metrics.find do |m|
-      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
-    end
-    assert(metric, "No result metric found for this test")
-    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
-    assert_includes(metric.tags, "status:failure")
-  end
+#     metric = metrics.find do |m|
+#       m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{bad_ns}")
+#     end
+#     assert(metric, "No result metric found for this test")
+#     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+#     assert_includes(metric.tags, "status:failure")
+#   end
 
-  def test_success_statsd_metric_emitted
-    deploy_task_template
-    task_runner = build_task_runner
+#   def test_success_statsd_metric_emitted
+#     deploy_task_template
+#     task_runner = build_task_runner
 
-    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(**run_params.merge(verify_result: false))
-      assert_task_run_success(result)
-    end
+#     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+#       result = task_runner.run(**run_params.merge(verify_result: false))
+#       assert_task_run_success(result)
+#     end
 
-    metric = metrics.find do |m|
-      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
-    end
-    assert(metric, "No result metric found for this test")
-    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
-    assert_includes(metric.tags, "status:success")
-  end
+#     metric = metrics.find do |m|
+#       m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
+#     end
+#     assert(metric, "No result metric found for this test")
+#     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+#     assert_includes(metric.tags, "status:success")
+#   end
 
-  def test_timedout_statsd_metric_emitted
-    deploy_task_template
-    task_runner = build_task_runner(global_timeout: 0)
+#   def test_timedout_statsd_metric_emitted
+#     deploy_task_template
+#     task_runner = build_task_runner(global_timeout: 0)
 
-    metrics = capture_statsd_calls(client: Krane::StatsD.client) do
-      result = task_runner.run(**run_params.merge(arguments: ["sleep 5"]))
-      assert_task_run_failure(result, :timed_out)
-    end
+#     metrics = capture_statsd_calls(client: Krane::StatsD.client) do
+#       result = task_runner.run(**run_params.merge(arguments: ["sleep 5"]))
+#       assert_task_run_failure(result, :timed_out)
+#     end
 
-    metric = metrics.find do |m|
-      m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
-    end
-    assert(metric, "No result metric found for this test")
-    assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
-    assert_includes(metric.tags, "status:timeout")
-  end
-end
+#     metric = metrics.find do |m|
+#       m.name == "Krane.task_runner.duration" && m.tags.include?("namespace:#{@namespace}")
+#     end
+#     assert(metric, "No result metric found for this test")
+#     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
+#     assert_includes(metric.tags, "status:timeout")
+#   end
+# end

--- a/test/integration-serial/serial_task_run_test.rb
+++ b/test/integration-serial/serial_task_run_test.rb
@@ -82,4 +82,4 @@ class SerialTaskRunTest < Krane::IntegrationTest
     assert_includes(metric.tags, "context:#{KubeclientHelper::TEST_CONTEXT}")
     assert_includes(metric.tags, "status:timeout")
   end
-# end
+end

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -40,20 +40,22 @@ class KraneDeployTest < Krane::IntegrationTest
     assert_deploy_failure(deploy_raw_fixtures("empty-resources", subset: %w[empty1.yml empty2.yml]))
 
     assert_logs_match_all([
-                            "All required parameters and files are present",
-                            "Result: FAILURE",
-                            "No deployable resources were found!",
-                          ], in_order: true)
+      "All required parameters and files are present",
+      "Result: FAILURE",
+      "No deployable resources were found!",
+    ], in_order: true)
   end
 
   def test_deploy_fails_with_empty_erb
-    assert_deploy_failure(deploy_raw_fixtures("empty-resources", subset: %w[empty3.yml.erb empty4.yml.erb], render_erb: true))
+    assert_deploy_failure(
+      deploy_raw_fixtures("empty-resources", subset: %w[empty3.yml.erb empty4.yml.erb], render_erb: true)
+    )
 
     assert_logs_match_all([
-                            "All required parameters and files are present",
-                            "Result: FAILURE",
-                            "No deployable resources were found!",
-                          ], in_order: true)
+      "All required parameters and files are present",
+      "Result: FAILURE",
+      "No deployable resources were found!",
+    ], in_order: true)
   end
 
   def test_service_account_predeployed_before_unmanaged_pod
@@ -135,7 +137,7 @@ class KraneDeployTest < Krane::IntegrationTest
       prune_matcher("role", "rbac.authorization.k8s.io", "role"),
       prune_matcher("rolebinding", "rbac.authorization.k8s.io", "role-binding"),
       prune_matcher("persistentvolumeclaim", "", "hello-pv-claim"),
-      prune_matcher("ingress", %w(networking.k8s.io extensions), "web")
+      prune_matcher("ingress", %w(networking.k8s.io extensions), "web"),
     ] # not necessarily listed in this order
     expected_msgs = [/Pruned 2[013] resources and successfully deployed 6 resources/]
     expected_pruned.map do |resource|

--- a/test/unit/krane/kubernetes_resource/custom_resource_definition_test.rb
+++ b/test/unit/krane/kubernetes_resource/custom_resource_definition_test.rb
@@ -96,6 +96,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: @statsd_tags, crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => { "name" => "test" },
       })
     cr.validate_definition(kubectl: kubectl)
@@ -129,6 +130,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => { "name" => "test" },
       })
     cr.validate_definition(kubectl: kubectl)
@@ -154,7 +156,11 @@ class CustomResourceDefinitionTest < Krane::TestCase
     ))
     cr = Krane::KubernetesResource.build(namespace: "test", context: "test",
       logger: @logger, statsd_tags: [], crd: crd,
-      definition: { "kind" => "UnitTest", "metadata" => { "name" => "test" } })
+      definition: {
+        "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
+        "metadata" => { "name" => "test" },
+      })
     assert_equal(cr.timeout, 60)
   end
 
@@ -171,6 +177,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => {
           "name" => "test",
         },
@@ -195,6 +202,7 @@ class CustomResourceDefinitionTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => {
           "name" => "test",
         },

--- a/test/unit/resource_cache_test.rb
+++ b/test/unit/resource_cache_test.rb
@@ -125,12 +125,13 @@ class ResourceCacheTest < Krane::TestCase
       logger: @logger, statsd_tags: [], crd: crd,
       definition: {
         "kind" => "UnitTest",
+        "apiVersion" => "stable.example.io/v1",
         "metadata" => {
           "name" => "test",
         },
       })
 
-    stub_kind_get("UnitTest", times: 1)
+    stub_kind_get("UnitTest.stable.example.io", times: 1)
     stub_kind_get("CustomResourceDefinition", times: 1)
     resources = [cr, crd]
     @cache.prewarm(resources)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fixes the problem whereby custom resources can not discriminate between the same kind in different groups. This actually involved changes to `#predeploy_sequence` and `CustomResource(Definition)`

Note this doesn't solve the wider problem of multiple kinds among different standard API groups: that will require more changes than what's here
