### PR TITLE
Actively monitor nodes status for DaemonSet deployments

### DIFF
--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -79,13 +79,12 @@ module Krane
 
     def find_nodes(cache)
       all_nodes = cache.get_all(Node.kind)
-      all_nodes = all_nodes.select { |node_data| node_data.dig('spec', 'unschedulable').to_s.downcase != 'true' }
-      all_nodes = all_nodes.select do |node_data| 
+      all_nodes.each_with_object([]) do |node_data, relevant_nodes|
+        next if node_data.dig('spec', 'unschedulable').to_s.downcase == 'true'
         cond = node_data.dig('status', 'conditions').find { |c| c['type'].downcase == 'ready' }
-        cond.nil? ? true : cond['status'].downcase == 'true' 
+        next if (!cond.nil? && cond['status'].downcase != 'true')
+        relevant_nodes << Node.new(definition: node_data)
       end
-
-      all_nodes.map { |node_data| Node.new(definition: node_data) }
     end
 
     def rollout_data

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -94,14 +94,6 @@ class DaemonSetTest < Krane::TestCase
     ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
     refute_predicate(ds, :deploy_succeeded?)
 
-    node_added_status = {
-      "desiredNumberScheduled": 3,
-      "updatedNumberScheduled": 3,
-      "numberReady": 2,
-    }
-    ds_template = build_ds_template(filename: 'daemon_set.yml', status: node_added_status)
-    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
-
     # node 2 Pod Ready status is False, if the node is unschedulable it should not account as blocking
     node_templates[2]['spec']['unschedulable'] = 'true'
 
@@ -124,15 +116,7 @@ class DaemonSetTest < Krane::TestCase
     ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
     refute_predicate(ds, :deploy_succeeded?)
 
-    node_added_status = {
-      "desiredNumberScheduled": 3,
-      "updatedNumberScheduled": 3,
-      "numberReady": 2,
-    }
-    ds_template = build_ds_template(filename: 'daemon_set.yml', status: node_added_status)
-    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
-
-    # node 2 Pod Ready status is False, if the node is unschedulable it should not account as blocking
+    # node 2 Pod Ready status is False, if the node is not ready it should not account as blocking
     node_templates[2]['status']['conditions'].find { |c| c['type'].downcase == 'ready' }['status'] = 'False'
 
     stub_kind_get("DaemonSet", items: [ds_template])

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -77,6 +77,67 @@ class DaemonSetTest < Krane::TestCase
 
     stub_kind_get("DaemonSet", items: [ds_template])
     stub_kind_get("Pod", items: pod_templates)
+    stub_kind_get("Node", items: node_templates, use_namespace: false)
+    ds.sync(build_resource_cache)
+    assert_predicate(ds, :deploy_succeeded?)
+  end
+
+  def test_deploy_passes_when_nodes_unschedulable
+    status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+    node_templates = load_fixtures(filenames: ['nodes.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
+
+    node_added_status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: node_added_status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+
+    # node 2 Pod Ready status is False, if the node is unschedulable it should not account as blocking
+    node_templates[2]['spec']['unschedulable'] = 'true'
+
+    stub_kind_get("DaemonSet", items: [ds_template])
+    stub_kind_get("Pod", items: pod_templates)
+    stub_kind_get("Node", items: node_templates, use_namespace: false)
+    ds.sync(build_resource_cache)
+    assert_predicate(ds, :deploy_succeeded?)
+  end
+
+  def test_deploy_passes_when_nodes_not_ready
+    status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+    node_templates = load_fixtures(filenames: ['nodes.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
+
+    node_added_status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: node_added_status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+
+    # node 2 Pod Ready status is False, if the node is unschedulable it should not account as blocking
+    node_templates[2]['status']['conditions'].find { |c| c['type'].downcase == 'ready' }['status'] = 'False'
+
+    stub_kind_get("DaemonSet", items: [ds_template])
+    stub_kind_get("Pod", items: pod_templates)
+    stub_kind_get("Node", items: node_templates, use_namespace: false)
     ds.sync(build_resource_cache)
     assert_predicate(ds, :deploy_succeeded?)
   end
@@ -123,6 +184,7 @@ class DaemonSetTest < Krane::TestCase
     ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
     stub_kind_get("DaemonSet", items: [ds_template])
     stub_kind_get("Pod", items: [ready_pod_template])
+    stub_kind_get("Node", items: node_templates, use_namespace: false)
     ds.sync(build_resource_cache)
     assert_predicate(ds, :deploy_succeeded?)
   end


### PR DESCRIPTION
This PR is a completion of the original implementation in https://github.com/Shopify/krane/pull/580

In the original implementation, the list of nodes is fetched when the deployment start and then is fixed. if one of the nodes goes away / becomes unschedulable while daemonsets are rolling out, it keeps waiting indefinitely.

This PR aims to make the node list dynamic.

It also now filters out unschedulable / not ready nodes.

This should replace the `required-rollout` PR https://github.com/Shopify/krane/pull/878