### PR TITLE
Ignore Evicted Pods in DaemonSet deployments

### DIFF
--- a/lib/krane/kubernetes_resource/daemon_set.rb
+++ b/lib/krane/kubernetes_resource/daemon_set.rb
@@ -59,7 +59,7 @@ module Krane
     def relevant_pods_ready?
       return true if rollout_data["desiredNumberScheduled"].to_i == rollout_data["numberReady"].to_i # all pods ready
       relevant_node_names = @nodes.map(&:name)
-      considered_pods = @pods.select { |p| relevant_node_names.include?(p.node_name) }
+      considered_pods = @pods.select { |p| relevant_node_names.include?(p.node_name) && !p.evicted? }
       @logger.debug("DaemonSet is reporting #{rollout_data['numberReady']} pods ready." \
         " Considered #{considered_pods.size} pods out of #{@pods.size} for #{@nodes.size} nodes.")
       considered_pods.present? &&

--- a/lib/krane/kubernetes_resource/pod.rb
+++ b/lib/krane/kubernetes_resource/pod.rb
@@ -105,6 +105,10 @@ module Krane
       @instance_data.dig('spec', 'nodeName')
     end
 
+    def evicted?
+      phase == "Failed" && reason == "Evicted"
+    end
+
     private
 
     def failed_schedule_reason

--- a/test/unit/krane/kubernetes_resource/daemon_set_test.rb
+++ b/test/unit/krane/kubernetes_resource/daemon_set_test.rb
@@ -126,6 +126,32 @@ class DaemonSetTest < Krane::TestCase
     assert_predicate(ds, :deploy_succeeded?)
   end
 
+  def test_deploy_passes_when_pod_evicted
+    status = {
+      "desiredNumberScheduled": 3,
+      "updatedNumberScheduled": 3,
+      "numberReady": 2,
+    }
+    ds_template = build_ds_template(filename: 'daemon_set.yml', status: status)
+    pod_templates = load_fixtures(filenames: ['daemon_set_pods.yml'])
+    node_templates = load_fixtures(filenames: ['nodes.yml'])
+    ds = build_synced_ds(ds_template: ds_template, pod_templates: pod_templates, node_templates: node_templates)
+    refute_predicate(ds, :deploy_succeeded?)
+
+    pod_templates[2]["status"] = {
+      "message": "Pod The node had condition: [DiskPressure].",
+      "phase": "Failed",
+      "reason": "Evicted",
+      "startTime": "2022-03-31T20:14:06Z"
+    }
+
+    stub_kind_get("DaemonSet", items: [ds_template])
+    stub_kind_get("Pod", items: pod_templates)
+    stub_kind_get("Node", items: node_templates, use_namespace: false)
+    ds.sync(build_resource_cache)
+    assert_predicate(ds, :deploy_succeeded?)
+  end
+
   def test_deploy_fails_when_not_all_pods_updated
     status = {
       "desiredNumberScheduled": 2,


### PR DESCRIPTION
Related to https://github.com/Shopify/krane/pull/881

Another case where `DaemonSet` deployment fails, when a node condition triggers an eviction, such as:

On the Pod:
```
status:
  message: 'Pod The node had condition: [DiskPressure]. '
  phase: Failed
  reason: Evicted
  startTime: "2022-03-31T20:14:06Z"
```

On the node:
```
spec:
  - effect: NoSchedule
    key: node.kubernetes.io/disk-pressure
    timeAdded: "2022-03-31T20:27:09Z"
status:
  conditions:
    - lastHeartbeatTime: "2022-03-31T20:27:29Z"
    lastTransitionTime: "2022-03-31T20:27:09Z"
    message: kubelet has disk pressure
    reason: KubeletHasDiskPressure
    status: "True"
    type: DiskPressure
```

This PR removes Evicted Pods from the list of `Pod` we expect to be ready for a `DaemonSet` deployment to be successful.
