### PR TITLE
Release 2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## next
 
+## 2.4.4
+
+*Enhancements*
+
+- Improve DaemonSet rollout by ignoring `Evicted` Pods [#883](https://github.com/Shopify/krane/pull/883)
+
 ## 2.4.3
 
 *Enhancements*

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.4.3"
+  VERSION = "2.4.4"
 end


### PR DESCRIPTION
Release includes:

* Ignore Evicted Pods in DaemonSet deployments https://github.com/Shopify/krane/pull/883