### PR TITLE
Revert PR that tried to fail fast when there are container initialization issues to give pods time to be recreated and possible succeed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## next
 
+## 2.4.5
+
+*Bug fixes*
+
+- Revert PR that tried to fail fast when there are container initialization issues to give pods time to be recreated and possible succeed [#885](https://github.com/Shopify/krane/pull/885)
+
 ## 2.4.4
 
 *Enhancements*

--- a/lib/krane/kubernetes_resource/pod.rb
+++ b/lib/krane/kubernetes_resource/pod.rb
@@ -229,7 +229,9 @@ module Krane
         elsif limbo_reason == "ErrImagePull" && limbo_message.match(/not found/i)
           "Failed to pull image #{@image}. "\
           "Did you wait for it to be built and pushed to the registry before deploying?"
-        elsif limbo_reason == "CreateContainerConfigError"
+        # Only fail fast when message doesn't include `failed to sync secret cache`.
+        # It's possible that a secret is being created and the pod could get recreated and succeed
+        elsif limbo_reason == "CreateContainerConfigError" && !limbo_message.include?("failed to sync secret cache")
           "Failed to generate container configuration: #{limbo_message}"
         elsif @status.dig("lastState", "terminated", "reason") == "ContainerCannotRun"
           # ref: https://github.com/kubernetes/kubernetes/blob/562e721ece8a16e05c7e7d6bdd6334c910733ab2/pkg/kubelet/dockershim/docker_container.go#L353

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.4.4"
+  VERSION = "2.4.5"
 end


### PR DESCRIPTION
Intention is to stop failing fast and give the pod time to be recreated while the secret is being created, my theory is that with more time the pod will be able to run (with some kubernetes retries) after the secret is finally created.

What would be the side effect of reverting this?:
- I can think of some deploys are going to take more time to fail, but they will eventually give up (retries) and will fail as something is wrong trying to create the pod, it just that it will take more time to return the deployment result.

Reverts https://github.com/Shopify/krane/pull/218