### PR TITLE
Do not fail fast for `CreateContainerConfigError` and sync cache issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,18 @@
 ## next
 
+## 2.4.6
+
+*Bug fixes*
+
+- Extend [#886](https://github.com/Shopify/krane/pull/886) to not only secrets but anything that doesn't match `failed to sync %s cache` [#886](https://github.com/Shopify/krane/pull/886)
+It seems an issue when too many pods are referencing the same secret/configmap https://github.com/kubernetes/kubernetes/pull/74755, so instead of failing fast, it'll now let the resources attempt to succeed.
+- Add missing unit test for above feature.
+
 ## 2.4.5
 
 *Bug fixes*
 
-- Revert PR that tried to fail fast when there are container initialization issues to give pods time to be recreated and possible succeed [#885](https://github.com/Shopify/krane/pull/885)
+- Do not fail fast for CreateContainerConfigError when message include issues mounting the secret, to let the pods be recreated and possible succeed [#885](https://github.com/Shopify/krane/pull/885)
 
 ## 2.4.4
 

--- a/lib/krane/kubernetes_resource/pod.rb
+++ b/lib/krane/kubernetes_resource/pod.rb
@@ -229,9 +229,11 @@ module Krane
         elsif limbo_reason == "ErrImagePull" && limbo_message.match(/not found/i)
           "Failed to pull image #{@image}. "\
           "Did you wait for it to be built and pushed to the registry before deploying?"
-        # Only fail fast when message doesn't include `failed to sync secret cache`.
-        # It's possible that a secret is being created and the pod could get recreated and succeed
-        elsif limbo_reason == "CreateContainerConfigError" && !limbo_message.include?("failed to sync secret cache")
+          # Only fail fast when message doesn't include `failed to sync %s cache`.
+          # It's possible that a secret/configmap is still trying to be mounted to the pod, it seems related
+          # to too many pods referencing the same secret/configmap: https://github.com/kubernetes/kubernetes/pull/74755
+          # Error message format source: https://github.com/kubernetes/kubernetes/pull/75260
+        elsif limbo_reason == "CreateContainerConfigError" && !limbo_message.match("failed to sync (.*?) cache")
           "Failed to generate container configuration: #{limbo_message}"
         elsif @status.dig("lastState", "terminated", "reason") == "ContainerCannotRun"
           # ref: https://github.com/kubernetes/kubernetes/blob/562e721ece8a16e05c7e7d6bdd6334c910733ab2/pkg/kubelet/dockershim/docker_container.go#L353

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.4.5"
+  VERSION = "2.4.6"
 end

--- a/test/unit/krane/kubernetes_resource/pod_test.rb
+++ b/test/unit/krane/kubernetes_resource/pod_test.rb
@@ -94,6 +94,48 @@ class PodTest < Krane::TestCase
     assert_equal(expected_msg.strip, pod.failure_message)
   end
 
+  def test_deploy_failed_is_false_for_create_container_config_error_and_failed_to_sync_secret_msg
+    container_state = {
+      "state" => {
+        "waiting" => {
+          "message" => "failed to sync secret cache: timed out waiting for the condition",
+          "reason" => "CreateContainerConfigError"
+        },
+      },
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+
+    assert(!pod.deploy_failed?)
+  end
+
+  def test_deploy_failed_is_false_for_create_container_config_error_and_failed_to_sync_configmap_msg
+    container_state = {
+      "state" => {
+        "waiting" => {
+          "message" => "failed to sync configmap cache: timed out waiting for the condition",
+          "reason" => "CreateContainerConfigError"
+        },
+      },
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+
+    assert(!pod.deploy_failed?)
+  end
+
+  def test_deploy_failed_is_false_for_create_container_config_error_and_failed_to_sync_any_other_resource
+    container_state = {
+      "state" => {
+        "waiting" => {
+          "message" => "failed to sync xxx cache: timed out waiting for the condition",
+          "reason" => "CreateContainerConfigError"
+        },
+      },
+    }
+    pod = build_synced_pod(build_pod_template(container_state: container_state))
+
+    assert(!pod.deploy_failed?)
+  end
+
   def test_deploy_failed_is_true_for_crash_loop_backoffs
     container_state = {
       "lastState" => {


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

It seems kubernetes might have issues mounting the same secret/configmap in many pods that causes
the pod to be in a `CreateContainerConfigError` state and an error message `failed to sync %s
cache`.

This PR stop failing fast for that case and will let kubernetes to try to eventually run the
pod (after some time and a new pod is created we've seen this issue to be resolved by it self).


Code path will still fail fast if the secret/configmap doesn't exists, the error message is different:
```yaml
    state:
      waiting:
        message: secret "redis-url" not found
        reason: CreateContainerConfigError


    State:          Waiting
      Reason:       CreateContainerConfigError
```
