### PR TITLE
Use json format for kubectl version requests

### DIFF
--- a/test/unit/krane/ejson_secret_provisioner_test.rb
+++ b/test/unit/krane/ejson_secret_provisioner_test.rb
@@ -133,7 +133,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   private
 
   def stub_server_dry_run_validation_request(attempts: 3)
-    stub_kubectl_response("apply", "-f", anything, "--server-dry-run", "--output=name",
+    stub_kubectl_response("apply", "-f", anything, "--dry-run=server", "--output=name",
       resp: dummy_secret_hash, json: false,
       kwargs: {
         log_failure: false,
@@ -145,7 +145,7 @@ class EjsonSecretProvisionerTest < Krane::TestCase
 
   def stub_server_dry_run_version_request(attempts: 1)
     stub_kubectl_response("version",
-      resp: dummy_version, json: false,
+      resp: dummy_version,
         kwargs: {
           use_namespace: false,
           log_failure: true,
@@ -193,9 +193,30 @@ class EjsonSecretProvisionerTest < Krane::TestCase
   end
 
   def dummy_version
-    'Server: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.6", GitCommit:"a6a8ec"}' \
-      "\n" \
-      'Client:: version.Info{Major:"1", Minor:"13", GitVersion:"v1.13.6", GitCommit:"70132b"'
+    {
+      "clientVersion": {
+        "major": "1",
+        "minor": "23",
+        "gitVersion": "v1.23.1",
+        "gitCommit": "86ec240af8cbd1b60bcc4c03c20da9b98005b92e",
+        "gitTreeState": "clean",
+        "buildDate": "2021-12-16T11:33:37Z",
+        "goVersion": "go1.17.5",
+        "compiler": "gc",
+        "platform": "darwin/arm64"
+      },
+      "serverVersion": {
+        "major": "1",
+        "minor": "23",
+        "gitVersion": "v1.23.4",
+        "gitCommit": "e6c093d87ea4cbb530a7b2ae91e54c0842d8308a",
+        "gitTreeState": "clean",
+        "buildDate": "2022-03-06T21:39:59Z",
+        "goVersion": "go1.17.7",
+        "compiler": "gc",
+        "platform": "linux/arm64"
+      }
+    }
   end
 
   def build_provisioner(dir = nil, selector: nil, ejson_keys_secret: dummy_ejson_secret)

--- a/test/unit/krane/kubectl_test.rb
+++ b/test/unit/krane/kubectl_test.rb
@@ -183,7 +183,7 @@ class KubectlTest < Krane::TestCase
 
   def test_version_info_raises_if_command_fails
     stub_open3(
-      %W(kubectl version --context=testc --request-timeout=#{timeout}),
+      %W(kubectl version --context=testc --output=json --request-timeout=#{timeout}),
       resp: '', err: 'bad', success: false
     ).times(2)
     assert_raises_message(Krane::KubectlError, "Could not retrieve kubectl version info") do
@@ -392,18 +392,23 @@ class KubectlTest < Krane::TestCase
   end
 
   def stub_version_request(client:, server:)
-    resp = <<~STRING
-      Client Version: #{client}
-      Server Version: #{server}
-    STRING
-    stub_open3(%W(kubectl version --context=testc --request-timeout=#{timeout}), resp: resp)
+    resp = { "clientVersion": client, "serverVersion": server }
+    stub_open3(%W(kubectl version --context=testc --output=json --request-timeout=#{timeout}), resp: resp.to_json)
   end
 
   def version_info(maj, min, patch, git: nil)
     git ||= "v#{maj}.#{min}.#{patch}"
-    <<~STRING
-      version.Info{Major:"#{maj}", Minor:"#{min}", GitVersion:"#{git}", GitCommit:"somecommit", GitTreeState:"clean", BuildDate:"2017-09-27T21:21:34Z", GoVersion:"go1.8.3", Compiler:"gc", Platform:"linux/amd64"}
-    STRING
+    {
+      "major": maj,
+      "minor": min,
+      "gitVersion": git,
+      "gitCommit": "86ec240af8cbd1b60bcc4c03c20da9b98005b92e",
+      "gitTreeState": "clean",
+      "buildDate": "2021-12-16T11:33:37Z",
+      "goVersion": "go1.17.5",
+      "compiler": "gc",
+      "platform": "darwin/arm64"
+    }
   end
 
   def build_kubectl(log_failure_by_default: true, kubeconfig: nil)


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
The "long" golang output format for `kubectl version` is being deprecated and removed. We should really be using json (or yaml) instead. https://github.com/kubernetes/kubernetes/pull/108987

**How is this accomplished?**
Updating the kubectl class and related tests.

**What could go wrong?**
If the JSON payload does not contain the expected keys, we'll raise a KubectlError. Previously, we would cache an empty hash. I think the explicit error is preferable to whatever would go wrong down the line with the empty hash.