### PR TITLE
Bs/update googleauth version in gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 ## next
 
+## 2.4.8
+
+- update googleauth gem version to 1.2
+- add the `ruby-lsp` gem to development group in the Gemfile
 ## 2.4.7
 
 *Bug fixes*
 
-- Fix `replace-force` deployment method override. 
+- Fix `replace-force` deployment method override.
 ```
 /usr/local/bundle/gems/krane-2.4.6/lib/krane/resource_deployer.rb:119:in `block in deploy_resources': Unexpected deploy method! (:"replace-force") (ArgumentError)
 ```

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,5 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in krane.gemspec
 gemspec
+
+gem "ruby-lsp", "~> 0.2.0", :group => :development

--- a/krane.gemspec
+++ b/krane.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6.0'
   spec.add_dependency("activesupport", ">= 5.0")
   spec.add_dependency("kubeclient", "~> 4.9")
-  spec.add_dependency("googleauth", "~> 0.8")
+  spec.add_dependency("googleauth", "~> 1.2")
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
   spec.add_dependency("statsd-instrument", ['>= 2.8', "< 4"])

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "2.4.7"
+  VERSION = "2.4.8"
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
update googleauth gem dependancy from 0.8 to 1.2 

**How is this accomplished?**
updated the dependancy in the `krane.gemspec`

**What could go wrong?**
the minimum ruby version is `Updated minimum Ruby version to 2.6` 

