### PR TITLE
Update YAML.safe_load call to be compatible with Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         ruby:
         # Use unique Ruby versions, or GitHub gets confused when building the rest of the matrix
+        - '3.1.2' # With k8s 1.23
         - '3.0.3' # With k8s 1.23
         - '3.0.2' # With k8s 1.22
         - '3.0.1' # With k8s 1.21
@@ -19,6 +20,10 @@ jobs:
         - '2.7' # With k8s 1.19
         include:
         # Match kind images with chosen version https://github.com/kubernetes-sigs/kind/releases
+        - ruby: '3.1.2'
+          kind_version: 'v0.11.1'
+          kubernetes_version: '1.23.0'
+          kind_image: 'kindest/node:v1.23.0@sha256:49824ab1727c04e56a21a5d8372a402fcd32ea51ac96a2706a12af38934f81ac'
         - ruby: '3.0.3'
           kind_version: 'v0.11.1'
           kubernetes_version: '1.23.0'

--- a/lib/krane/bindings_parser.rb
+++ b/lib/krane/bindings_parser.rb
@@ -41,7 +41,8 @@ module Krane
         when '.json'
           bindings = parse_json(File.read(file_path))
         when '.yaml', '.yml'
-          bindings = YAML.safe_load(File.read(file_path), [], [], true, file_path)
+          bindings = YAML.safe_load(File.read(file_path), permitted_classes: [], permitted_symbols: [], 
+                                    aliases: true, filename: file_path)
         else
           raise ArgumentError, "Supplied file does not appear to be JSON or YAML"
         end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

When krane is run under Ruby 3.1, and is invoked with an argument like `--bindings=@somefile`, it crashes, because the binding code is loading `somefile` using a deprecated call format for `YAML.safe_load` that is no longer valid in Ruby 3.1.

This is also causing unit test failures when the tests are run under Ruby 3.1.

**How is this accomplished?**

The `safe_load` call is fixed to use the current arguments, which are valid for Ruby 2.7 and later.

**What could go wrong?**

Probably nothing since there's test coverage for this. The PR also adds Ruby 3.1 to the GitHub action test matrix to cover this case.

