### PR TITLE
make LimitRange resource a priority resource

### DIFF
--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -68,6 +68,7 @@ module Krane
         Role
         RoleBinding
         Secret
+        LimitRange
       ).map { |r| [r, default_group] }
 
       after_crs = %w(


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
When deploying to a new cluster with a custom resource quote, a CRD fails to deploy because it does not have explicit limits/requests for its container(s).

The deploy includes a LimitRange resource, but since it's not a "priority" resource it is not deployed before the CRD.

**How is this accomplished?**
Adding LimitRange to the list of priority resource should fix this.

**What could go wrong?**
It's possible that there are CRDs we want deployed before a LimitRange ?

NOTE: unsure how to test this, so I'd welcome a point in the right direction -- while I'm digging further

