### PR TITLE
stop pruning events on deploy to avoid timeouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## next
 
+- Add `Event` to the list of resources not to be pruned on a deployment.  Kubernetes should clean these up automatically. This can cause unnessessary deployment timeouts and increased deployment time.
 
 ## 3.0.0
 

--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -19,7 +19,7 @@ module Krane
     end
 
     def prunable_resources(namespaced:)
-      black_list = %w(Namespace Node ControllerRevision)
+      black_list = %w(Namespace Node ControllerRevision Event)
       fetch_resources(namespaced: namespaced).map do |resource|
         next unless resource["verbs"].one? { |v| v == "delete" }
         next if black_list.include?(resource["kind"])

--- a/test/unit/cluster_resource_discovery_test.rb
+++ b/test/unit/cluster_resource_discovery_test.rb
@@ -45,11 +45,11 @@ class ClusterResourceDiscoveryTest < Krane::TestCase
     crd = mocked_cluster_resource_discovery
     kinds = crd.prunable_resources(namespaced: true).map { |k| k.split('/').last }.uniq
 
-    assert_equal(24, kinds.length)
+    assert_equal(23, kinds.length)
     %w(ConfigMap CronJob Deployment).each do |expected_kind|
       assert(kinds.one? { |k| k.include?(expected_kind) })
     end
-    %w(controllerrevision).each do |black_listed_kind|
+    %w(controllerrevision event).each do |black_listed_kind|
       assert_empty(kinds.select { |k| k.downcase.include?(black_listed_kind) })
     end
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Closes https://github.com/Shopify/krane/issues/908

**How is this accomplished?**
This PR adds `Event` to the deny list of resources to prune on deploy.
