### PR TITLE
Optimize chance of users reading error messages

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -255,22 +255,6 @@ module Krane
 
     def debug_message(cause = nil, info_hash = {})
       helpful_info = []
-      if cause == :gave_up
-        debug_heading = ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow
-        helpful_info << "If you expected it to take longer than #{info_hash[:timeout]} seconds for your deploy"\
-        " to roll out, increase --global-timeout."
-      elsif deploy_failed?
-        debug_heading = ColorizedString.new("#{id}: FAILED").red
-        helpful_info << failure_message if failure_message.present?
-      elsif deploy_timed_out?
-        debug_heading = ColorizedString.new("#{id}: TIMED OUT (#{pretty_timeout_type})").yellow
-        helpful_info << timeout_message if timeout_message.present?
-      else
-        # Arriving in debug_message when we neither failed nor timed out is very unexpected. Dump all available info.
-        debug_heading = ColorizedString.new("#{id}: MONITORING ERROR").red
-        helpful_info << failure_message if failure_message.present?
-        helpful_info << timeout_message if timeout_message.present? && timeout_message != STANDARD_TIMEOUT_MESSAGE
-      end
 
       final_status = "  - Final status: #{status}"
       final_status = "\n#{final_status}" if helpful_info.present? && !helpful_info.last.end_with?("\n")
@@ -310,6 +294,23 @@ module Krane
             end
           end
         end
+      end
+
+      if cause == :gave_up
+        debug_heading = ColorizedString.new("#{id}: GLOBAL WATCH TIMEOUT (#{info_hash[:timeout]} seconds)").yellow
+        helpful_info << "If you expected it to take longer than #{info_hash[:timeout]} seconds for your deploy"\
+        " to roll out, increase --global-timeout."
+      elsif deploy_failed?
+        debug_heading = ColorizedString.new("#{id}: FAILED").red
+        helpful_info << failure_message if failure_message.present?
+      elsif deploy_timed_out?
+        debug_heading = ColorizedString.new("#{id}: TIMED OUT (#{pretty_timeout_type})").yellow
+        helpful_info << timeout_message if timeout_message.present?
+      else
+        # Arriving in debug_message when we neither failed nor timed out is very unexpected. Dump all available info.
+        debug_heading = ColorizedString.new("#{id}: MONITORING ERROR").red
+        helpful_info << failure_message if failure_message.present?
+        helpful_info << timeout_message if timeout_message.present? && timeout_message != STANDARD_TIMEOUT_MESSAGE
       end
 
       helpful_info.join("\n")


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

In our experience, it is common for the other elements of debug output (primarily pod logs) to be long enough that they fill the screen, pushing the part of the output that most needs to call attention passing into scrollback. It is also very common for users to not scroll back appropriately, assuming the important output about a failure will be at the bottom of the output.

**How is this accomplished?**

This moves the important information to the bottom to increase the chance that a user will read it.

**What could go wrong?**

Users might still not read log output.
