### PR TITLE
Update hpa version to v2 for kubernetes 1.25

### DIFF
--- a/lib/krane/kubernetes_resource/horizontal_pod_autoscaler.rb
+++ b/lib/krane/kubernetes_resource/horizontal_pod_autoscaler.rb
@@ -16,7 +16,7 @@ module Krane
     end
 
     def kubectl_resource_type
-      'hpa.v2beta1.autoscaling'
+      'hpa.v2.autoscaling'
     end
 
     def status


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Trying to get krane to work with `1.25`

**How is this accomplished?**
Update the `kubectl_resource_type`

