### PR TITLE
[draft] Fix CI errors

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -43,11 +43,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency("yard")
 
   # Test framework
-  spec.add_development_dependency("minitest", "~> 5.12")
+  spec.add_development_dependency("minitest", "~> 5.19")
   spec.add_development_dependency("minitest-stub-const", "~> 0.6")
   spec.add_development_dependency("minitest-reporters")
-  spec.add_development_dependency("mocha", "~> 1.5")
-  spec.add_development_dependency("webmock", "~> 3.0")
+  spec.add_development_dependency("mocha", "~> 2.1")
+  spec.add_development_dependency("webmock", "~> 3.18")
   spec.add_development_dependency("timecop")
 
   # Debugging and analysis


### PR DESCRIPTION
**[please ignore this for now - still testing]** 

**What are you trying to accomplish with this PR?**
krane's CI tests are failing with `Mocha::ExpectationErrorFactory.exception_class = ::MiniTest::Assertion`. [Examples here.](https://github.com/Shopify/krane/actions/runs/5754487906/job/15599870368?pr=929) We think this is because `mocha` is out-of-date. 

**How is this accomplished?**
`mocha` has [fixed this error^](https://github.com/freerange/mocha/commit/32ef48f410189bb26abe574218306b612fc4de89) in a more recent version (2.1.0). This PR bumps mocha's version.

**What could go wrong?**
...
