### PR TITLE
Add dependabot and run weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 100
+    insecure-external-code-execution: allow
+    registries: "*"


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
[Dependabot](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#configuration-options-for-updates) opens pull requests to upgrade dependencies. Not required & totally up to maintainers, but could help with maintaining the health of krane long-term.

**How is this accomplished?**
Add dependabot.yml, configuring Dependabot to run weekly.

**What could go wrong?**
N/A ?