### PR TITLE
Remove the hard dependency on Oj

### DIFF
--- a/krane.gemspec
+++ b/krane.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency("ejson", "~> 1.0")
   spec.add_dependency("colorize", "~> 0.8")
   spec.add_dependency("statsd-instrument", ['>= 2.8', "< 4"])
-  spec.add_dependency("oj", "~> 3.0")
+  spec.add_dependency("multi_json")
   spec.add_dependency("concurrent-ruby", "~> 1.1")
   spec.add_dependency("jsonpath", "~> 1.0")
   spec.add_dependency("thor", ">= 1.0", "< 2.0")

--- a/lib/krane/bindings_parser.rb
+++ b/lib/krane/bindings_parser.rb
@@ -54,14 +54,14 @@ module Krane
     end
 
     def parse_json(string)
-      bindings = JSON.parse(string)
+      bindings = MultiJson.load(string)
 
       unless bindings.is_a?(Hash)
         raise ArgumentError, "Expected JSON data to be a hash."
       end
 
       bindings
-    rescue JSON::ParserError
+    rescue MultiJson::ParseError
       nil
     end
 

--- a/lib/krane/cli/krane.rb
+++ b/lib/krane/cli/krane.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 require 'krane'
-require 'krane/oj'
 require 'thor'
+require 'multi_json'
+
 require 'krane/cli/version_command'
 require 'krane/cli/restart_command'
 require 'krane/cli/run_command'

--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -54,7 +54,7 @@ module Krane
       @api_path_cache["/"] ||= begin
         raw_json, err, st = kubectl.run("get", "--raw", base_api_path, attempts: 5, use_namespace: false)
         paths = if st.success?
-          JSON.parse(raw_json)["paths"]
+          MultiJson.load(raw_json)["paths"]
         else
           raise FatalKubeAPIError, "Error retrieving raw path /: #{err}"
         end
@@ -66,7 +66,7 @@ module Krane
       @api_path_cache[path] ||= begin
         raw_json, err, st = kubectl.run("get", "--raw", path, attempts: 2, use_namespace: false)
         if st.success?
-          JSON.parse(raw_json)
+          MultiJson.load(raw_json)
         else
           logger.warn("Error retrieving api path: #{err}")
           {}
@@ -92,7 +92,7 @@ module Krane
       raw_json, err, st = kubectl.run("get", "CustomResourceDefinition", output: "json", attempts: 5,
         use_namespace: false)
       if st.success?
-        JSON.parse(raw_json)["items"]
+        MultiJson.load(raw_json)["items"]
       else
         raise FatalKubeAPIError, "Error retrieving CustomResourceDefinition: #{err}"
       end

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -328,7 +328,7 @@ module Krane
       @namespace_definition ||= begin
         definition, _err, st = kubectl.run("get", "namespace", @namespace, use_namespace: false,
           log_failure: true, raise_if_not_found: true, attempts: 3, output: 'json')
-        st.success? ? JSON.parse(definition, symbolize_names: true) : nil
+        st.success? ? MultiJson.load(definition, symbolize_names: true) : nil
       end
     rescue Kubectl::ResourceNotFoundError
       nil
@@ -362,7 +362,7 @@ module Krane
         unless st.success?
           raise EjsonSecretError, "Error retrieving Secret/#{EjsonSecretProvisioner::EJSON_KEYS_SECRET}: #{err}"
         end
-        JSON.parse(out)
+        MultiJson.load(out)
       end
     end
 

--- a/lib/krane/ejson_secret_provisioner.rb
+++ b/lib/krane/ejson_secret_provisioner.rb
@@ -117,8 +117,8 @@ module Krane
 
     def load_ejson_from_file
       return {} unless File.exist?(@ejson_file)
-      JSON.parse(File.read(@ejson_file))
-    rescue JSON::ParserError => e
+      MultiJson.load(File.read(@ejson_file))
+    rescue MultiJson::ParseError => e
       raise EjsonSecretError, "Failed to parse encrypted ejson:\n  #{e}"
     end
 
@@ -139,8 +139,8 @@ module Krane
         msg = err.presence || out
         raise EjsonSecretError, msg
       end
-      JSON.parse(out)
-    rescue JSON::ParserError
+      MultiJson.load(out)
+    rescue MultiJson::ParseError
       raise EjsonSecretError, "Failed to parse decrypted ejson"
     end
 

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -85,7 +85,7 @@ module Krane
           response, _, status = run("version", output: "json", use_namespace: false, log_failure: true, attempts: 2)
           raise KubectlError, "Could not retrieve kubectl version info" unless status.success?
 
-          version_data = JSON.parse(response)
+          version_data = MultiJson.load(response)
           client_version = platform_agnostic_version(version_data.dig("clientVersion", "gitVersion").to_s)
           server_version = platform_agnostic_version(version_data.dig("serverVersion", "gitVersion").to_s)
           unless client_version && server_version

--- a/lib/krane/oj.rb
+++ b/lib/krane/oj.rb
@@ -1,4 +1,0 @@
-# frozen_string_literal: true
-require 'oj'
-
-Oj.mimic_JSON

--- a/lib/krane/resource_cache.rb
+++ b/lib/krane/resource_cache.rb
@@ -64,7 +64,7 @@ module Krane
       raise KubectlError unless st.success?
 
       instances = {}
-      JSON.parse(raw_json)["items"].each do |resource|
+      MultiJson.load(raw_json)["items"].each do |resource|
         resource_name = resource.dig("metadata", "name")
         instances[resource_name] = resource
       end

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -252,7 +252,7 @@ module Krane
       # For resources that rely on a generateName attribute, we get the `name` from the result of the call to `create`
       # We must explicitly set this name value so that the `apply` step for pruning can run successfully
       if status.success? && resource.uses_generate_name?
-        resource.use_generated_name(JSON.parse(out))
+        resource.use_generated_name(MultiJson.load(out))
       end
 
       [err, status]

--- a/lib/krane/rollout_conditions.rb
+++ b/lib/krane/rollout_conditions.rb
@@ -11,7 +11,7 @@ module Krane
       def from_annotation(conditions_string)
         return new(default_conditions) if conditions_string.downcase.strip == "true"
 
-        conditions = JSON.parse(conditions_string).slice('success_conditions', 'failure_conditions')
+        conditions = MultiJson.load(conditions_string).slice('success_conditions', 'failure_conditions')
         conditions.deep_symbolize_keys!
 
         # Create JsonPath objects
@@ -26,7 +26,7 @@ module Krane
         end
 
         new(conditions)
-      rescue JSON::ParserError => e
+      rescue MultiJson::ParseError => e
         raise RolloutConditionsError, "Rollout conditions are not valid JSON: #{e}"
       rescue StandardError => e
         raise RolloutConditionsError,

--- a/test/helpers/cluster_resource_discovery_helper.rb
+++ b/test/helpers/cluster_resource_discovery_helper.rb
@@ -24,7 +24,7 @@ module ClusterResourceDiscoveryHelper
     Krane::Kubectl.any_instance.stubs(:run).with("get", "--raw", "/", attempts: 5, use_namespace: false)
       .returns([api_raw_full_response, "", stub(success?: success)])
 
-    paths = JSON.parse(api_raw_full_response)['paths'].select { |p| %r{^\/api.*\/v.*$}.match(p) }
+    paths = MultiJson.load(api_raw_full_response)['paths'].select { |p| %r{^\/api.*\/v.*$}.match(p) }
     paths.each do |path|
       Krane::Kubectl.any_instance.stubs(:run).with("get", "--raw", path, attempts: 2, use_namespace: false)
         .returns([apis_full_response(path), "", stub(success?: true)])

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -143,7 +143,7 @@ module FixtureDeployHelper
     fixtures = {}
     if !subset || subset.include?("secrets.ejson")
       ejson_file = File.join(fixture_path(set), EJSON_FILENAME)
-      fixtures[EJSON_FILENAME] = JSON.parse(File.read(ejson_file)) if File.exist?(ejson_file)
+      fixtures[EJSON_FILENAME] = MultiJson.load(File.read(ejson_file)) if File.exist?(ejson_file)
     end
 
     Dir.glob("#{fixture_path(set)}/*.{yml,yaml}*").each do |filename|


### PR DESCRIPTION
Opened in place of https://github.com/Shopify/krane/pull/923

---

I have been seeing the following in logs recently, it would be nice to remove Oj as @casperisfine intended to not only get faster json parsing and also get rid of this warning
```
WARNING: oj/json is a compatability shim used by Oj. Requiring the file explicitly is no recommended.
```