### PR TITLE
Test against Kubernetes v1.27

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,13 @@ jobs:
           - "3.0.4"
           - "2.7.6"
         kubernetes_version:
+          - "1.27.3"
           - "1.26.4"
           - "1.24.13"
           - "1.23.17"
         include:
+          - kubernetes_version: "1.27.3"
+            kind_image: "kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
           - kubernetes_version: "1.26.4"
             kind_image: "kindest/node:v1.26.4@sha256:a539833d26264444ab3b8f5e56e23fa3361436445fa23c864e6dec622458858f"
           - kubernetes_version: "1.24.13"

--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Krane provides support for official upstream supported versions [Kubernetes](htt
 |        1.24        | Yes               |                    --                    |
 |        1.25        | No                |                    --                    |
 |        1.26        | Yes               |                    --                    |
+|        1.27        | Yes               |                    --                    |
 
 ## Installation
 


### PR DESCRIPTION
As the PR title says, this modifies `ci.yml` so that we start testing `krane` against Kubernetes v1.27.