### PR TITLE
Rename default branch

### DIFF
--- a/1.0-Upgrade.md
+++ b/1.0-Upgrade.md
@@ -7,7 +7,7 @@
 * There are breaking changes in the public API (such as the renaming of the `KubernetesDeploy` namespace to `Krane`, and the change in default values for different arguments of the public interface).
 * StatsD metrics will now be generated with the `krane` prefix.
 * `krane deploy` now considers all namespaced resources eligible for pruning, including
-custom resources. See [blacklist](https://github.com/Shopify/krane/blob/master/lib/krane/cluster_resource_discovery.rb#L20) for exceptions.
+custom resources. See [blacklist](https://github.com/Shopify/krane/blob/main/lib/krane/cluster_resource_discovery.rb#L20) for exceptions.
 * `kubernetes-deploy` (now `krane deploy`) / `DeployTask` can no longer deploy global (non-namespaced) resources. A new command called `krane global-deploy` and a related class called `GlobalDeployTask` were added to replace that feature.
 * `krane deploy` will not render erb templates. Use `krane render | krane deploy --stdin` to reproduce this functionality.
 * If you attempt to install two gems that have conflicting executables, `gem install` will warn you but the most recently installed one will win.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -288,7 +288,7 @@ It seems an issue when too many pods are referencing the same secret/configmap h
 # 1.0.0
 
 We've renamed the gem and cli to Krane.
-See our [migration guide](https://github.com/Shopify/krane/blob/master/1.0-Upgrade.md) to help navigate the breaking changes.
+See our [migration guide](https://github.com/Shopify/krane/blob/main/1.0-Upgrade.md) to help navigate the breaking changes.
 
 ## 1.0.0.pre.2
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ The following is a set of guidelines for contributing to krane. Please take a mo
   * [CI (External contributors)](#ci-external-contributors)
 ## Code of Conduct
 
-This project and everyone participating in it are governed by the [Code of Conduct](https://github.com/Shopify/krane/blob/master/CODE_OF_CONDUCT.md).
+This project and everyone participating in it are governed by the [Code of Conduct](https://github.com/Shopify/krane/blob/main/CODE_OF_CONDUCT.md).
 By participating, you are expected to uphold this code. Please report unacceptable
 behavior to [krane@shopify.com](mailto:krane@shopify.com).
 
@@ -95,9 +95,9 @@ This gem uses subclasses of `KubernetesResource` to implement custom success/fai
     * `deploy_failed?`
 3. Adjust the `TIMEOUT` constant to an appropriate value for this type.
 4. Add the new class to list of resources in
-   [`deploy_task.rb`](https://github.com/Shopify/krane/blob/master/lib/krane/deploy_task.rb#L8)
-5. Add the new resource to the [prune whitelist](https://github.com/Shopify/krane/blob/master/lib/krane/deploy_task.rb#L81)
-6. Add a basic example of the type to the hello-cloud [fixture set](https://github.com/Shopify/krane/tree/master/test/fixtures/hello-cloud) and appropriate assertions to `#assert_all_up` in [`hello_cloud.rb`](https://github.com/Shopify/krane/blob/master/test/helpers/fixture_sets/hello_cloud.rb). This will get you coverage in several existing tests, such as `test_full_hello_cloud_set_deploy_succeeds`.
+   [`deploy_task.rb`](https://github.com/Shopify/krane/blob/main/lib/krane/deploy_task.rb#L8)
+5. Add the new resource to the [prune whitelist](https://github.com/Shopify/krane/blob/main/lib/krane/deploy_task.rb#L81)
+6. Add a basic example of the type to the hello-cloud [fixture set](https://github.com/Shopify/krane/tree/main/test/fixtures/hello-cloud) and appropriate assertions to `#assert_all_up` in [`hello_cloud.rb`](https://github.com/Shopify/krane/blob/main/test/helpers/fixture_sets/hello_cloud.rb). This will get you coverage in several existing tests, such as `test_full_hello_cloud_set_deploy_succeeds`.
 7. Add tests for any edge cases you foresee.
 
 ### Contributor License Agreement

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# krane [![Build status](https://badge.buildkite.com/35c56e797c3bbd6ba50053aefdded0715898cd8e8c86f7e462.svg?branch=master)](https://buildkite.com/shopify/krane)
+# krane [![Build status](https://badge.buildkite.com/35c56e797c3bbd6ba50053aefdded0715898cd8e8c86f7e462.svg?branch=main)](https://buildkite.com/shopify/krane)
 
-> This project used to be called `kubernetes-deploy`. Check out our [migration guide](https://github.com/Shopify/krane/blob/master/1.0-Upgrade.md) for more information including details about breaking changes.
+> This project used to be called `kubernetes-deploy`. Check out our [migration guide](https://github.com/Shopify/krane/blob/main/1.0-Upgrade.md) for more information including details about breaking changes.
 
 
 `krane` is a command line tool that helps you ship changes to a Kubernetes namespace and understand the result. At Shopify, we use it within our much-beloved, open-source [Shipit](https://github.com/Shopify/shipit-engine#kubernetes) deployment app.
@@ -337,7 +337,7 @@ status:
 
 ### Deploy walkthrough
 
-Let's walk through what happens when you run the `deploy` task with [this directory of templates](https://github.com/Shopify/krane/tree/master/test/fixtures/hello-cloud). This particular example uses ERB templates as well, so we'll use the [krane render](#krane-render) task to achieve that.
+Let's walk through what happens when you run the `deploy` task with [this directory of templates](https://github.com/Shopify/krane/tree/main/test/fixtures/hello-cloud). This particular example uses ERB templates as well, so we'll use the [krane render](#krane-render) task to achieve that.
 
 You can test this out for yourself by running the following command:
 
@@ -404,7 +404,7 @@ In this phase, we:
 
 Just like in the previous phase, we essentially run `kubectl apply` on those templates and periodically check the cluster for the current status of each resource so we can display error or success information.
 
-If pruning is enabled (which, again, is the default), any [kind not listed in the blacklist](https://github.com/Shopify/krane/blob/master/lib/krane/cluster_resource_discovery.rb#L20) that we can find in the namespace but not in the templates will be removed. A particular message about pruning will be printed in the next phase if any resource matches this criteria.
+If pruning is enabled (which, again, is the default), any [kind not listed in the blacklist](https://github.com/Shopify/krane/blob/main/lib/krane/cluster_resource_discovery.rb#L20) that we can find in the namespace but not in the templates will be removed. A particular message about pruning will be printed in the next phase if any resource matches this criteria.
 
 #### Result
 
@@ -654,13 +654,13 @@ This is a limitation of the current implementation.
 # Contributing
 
 We :heart: contributors! To make it easier for you and us we've written a
-[Contributing Guide](https://github.com/Shopify/krane/blob/master/CONTRIBUTING.md)
+[Contributing Guide](https://github.com/Shopify/krane/blob/main/CONTRIBUTING.md)
 
 
 You can also reach out to us on our slack channel, #krane, at https://kubernetes.slack.com. All are welcome!
 
 ## Code of Conduct
-Everyone is expected to follow our [Code of Conduct](https://github.com/Shopify/krane/blob/master/CODE_OF_CONDUCT.md).
+Everyone is expected to follow our [Code of Conduct](https://github.com/Shopify/krane/blob/main/CODE_OF_CONDUCT.md).
 
 
 # License

--- a/test/fixtures/slow-cloud/web-deploy-1.yml
+++ b/test/fixtures/slow-cloud/web-deploy-1.yml
@@ -4,7 +4,7 @@ metadata:
   name: web
   labels:
     name: web
-    branch: master
+    branch: main
     app: slow-cloud
   annotations:
     shipit.shopify.io/restart: "true"


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

These are changes to branch names to match the rename of the default branch for this repo from `master` to `main`.

**How is this accomplished?**

- Change documentation links to refer to `main` instead of `master` (links will break on rename)
- Change branch names used in test from `main` to `master` (would not break anything, but is in the spirit of the rename)

**What could go wrong?**

- Explicit references to the master branch may fail
- This is open source, and there are a lot of forks out there that may be impacted
