### PR TITLE
s/whitelist/allowlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # 3.4.0
 
-- Use `prune-allowlist` instead of `prune-whitelist`. This change requires kubernetes 1.26 and higher. [#940](https://github.com/Shopify/krane/pull/940)
+- Use `prune-allowlist` instead of `prune-whitelist` for 1.26+ clusters. Clusters running 1.25 or less will continue to use `--prune-whitelist`. [#940](https://github.com/Shopify/krane/pull/940)
 
 ## 3.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+# 3.4.0
+
+- Use `prune-allowlist` instead of `prune-whitelist`. This change requires kubernetes 1.26 and higher. [#940](https://github.com/Shopify/krane/pull/940)
+
 ## 3.3.0
 
 *Enhancements*

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Krane provides support for official upstream supported versions [Kubernetes](htt
 |        1.20        | No                |                  2.4.9                   |
 |        1.21        | No                |                  2.4.9                   |
 |        1.22        | No                |                  3.0.1                   |
-|        1.23        | Yes               |                    --                    |
-|        1.24        | Yes               |                    --                    |
-|        1.25        | No                |                    --                    |
+|        1.23        | Yes               |                  3.3.0                    |
+|        1.24        | Yes               |                  3.3.0                    |
+|        1.25        | No                |                  3.3.0                   |
 |        1.26        | Yes               |                    --                    |
 |        1.27        | Yes               |                    --                    |
 

--- a/README.md
+++ b/README.md
@@ -89,9 +89,9 @@ Krane provides support for official upstream supported versions [Kubernetes](htt
 |        1.20        | No                |                  2.4.9                   |
 |        1.21        | No                |                  2.4.9                   |
 |        1.22        | No                |                  3.0.1                   |
-|        1.23        | Yes               |                  3.3.0                    |
-|        1.24        | Yes               |                  3.3.0                    |
-|        1.25        | No                |                  3.3.0                   |
+|        1.23        | Yes               |                    --                    |
+|        1.24        | Yes               |                    --                    |
+|        1.25        | No                |                    --                    |
 |        1.26        | Yes               |                    --                    |
 |        1.27        | Yes               |                    --                    |
 

--- a/lib/krane/deploy_task.rb
+++ b/lib/krane/deploy_task.rb
@@ -77,7 +77,7 @@ module Krane
       Hash[before_crs + crs + after_crs]
     end
 
-    def prune_whitelist
+    def prune_allowlist
       cluster_resource_discoverer.prunable_resources(namespaced: true)
     end
 
@@ -192,7 +192,7 @@ module Krane
 
     def resource_deployer
       @resource_deployer ||= Krane::ResourceDeployer.new(task_config: @task_config,
-        prune_whitelist: prune_whitelist, global_timeout: @global_timeout,
+        prune_allowlist: prune_allowlist, global_timeout: @global_timeout,
         selector: @selector, statsd_tags: statsd_tags, current_sha: @current_sha)
     end
 

--- a/lib/krane/global_deploy_task.rb
+++ b/lib/krane/global_deploy_task.rb
@@ -108,7 +108,7 @@ module Krane
 
     def deploy!(resources, verify_result, prune)
       resource_deployer = ResourceDeployer.new(task_config: @task_config,
-        prune_whitelist: prune_whitelist, global_timeout: @global_timeout,
+        prune_allowlist: prune_allowlist, global_timeout: @global_timeout,
         selector: @selector, statsd_tags: statsd_tags)
       resource_deployer.deploy!(resources, verify_result, prune)
     end
@@ -194,7 +194,7 @@ module Krane
       @kubectl ||= Kubectl.new(task_config: @task_config, log_failure_by_default: true)
     end
 
-    def prune_whitelist
+    def prune_allowlist
       cluster_resource_discoverer.prunable_resources(namespaced: false)
     end
 

--- a/lib/krane/kubectl.rb
+++ b/lib/krane/kubectl.rb
@@ -12,6 +12,7 @@ module Krane
     DEFAULT_TIMEOUT = 15
     MAX_RETRY_DELAY = 16
     SERVER_DRY_RUN_MIN_VERSION = "1.13"
+    ALLOW_LIST_MIN_VERSION = "1.26"
 
     class ResourceNotFoundError < StandardError; end
 
@@ -110,6 +111,14 @@ module Krane
 
     def dry_run_flag
       "--dry-run=server"
+    end
+
+    def allowlist_flag
+      if client_version >= Gem::Version.new(ALLOW_LIST_MIN_VERSION)
+        "--prune-allowlist"
+      else
+        "--prune-whitelist"
+      end
     end
 
     private

--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -154,7 +154,8 @@ module Krane
           else
             command.push("--all")
           end
-          @prune_allowlist.each { |type| command.push("--prune-allowlist=#{type}") }
+          allow_list_flag = kubectl.allowlist_flag
+          @prune_allowlist.each { |type| command.push("#{allow_list_flag}=#{type}") }
         end
 
         command.push(kubectl.dry_run_flag) if dry_run

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.3.0"
+  VERSION = "3.4.0"
 end

--- a/test/unit/krane/resource_deployer_test.rb
+++ b/test/unit/krane/resource_deployer_test.rb
@@ -4,21 +4,22 @@ require 'krane/resource_deployer'
 
 class ResourceDeployerTest < Krane::TestCase
   def test_deploy_prune_builds_whitelist
-    whitelist_kind = "fake_kind"
+    allowlist_kind = "fake_kind"
     resource = build_mock_resource
+    Krane::Kubectl.any_instance.expects(:client_version).returns(Gem::Version.new("1.26"))
     Krane::Kubectl.any_instance.expects(:run).with do |*args|
-      args.include?("--prune-allowlist=#{whitelist_kind}")
+      args.include?("--prune-allowlist=#{allowlist_kind}")
     end.returns(["", "", stub(success?: true)])
-    resource_deployer(kubectl_times: 0, prune_allowlist: [whitelist_kind]).deploy!([resource], false, true)
+    resource_deployer(kubectl_times: 0, prune_allowlist: [allowlist_kind]).deploy!([resource], false, true)
   end
 
   def test_deploy_no_prune_doesnt_prune
-    whitelist_kind = "fake_kind"
+    allowlist_kind = "fake_kind"
     resource = build_mock_resource
     Krane::Kubectl.any_instance.expects(:run).with do |*args|
-      !args.include?("--prune-allowlist=#{whitelist_kind}")
+      !args.include?("--prune-allowlist=#{allowlist_kind}")
     end.returns(["", "", stub(success?: true)])
-    resource_deployer(kubectl_times: 0, prune_allowlist: [whitelist_kind]).deploy!([resource], false, false)
+    resource_deployer(kubectl_times: 0, prune_allowlist: [allowlist_kind]).deploy!([resource], false, false)
   end
 
   def test_deploy_verify_false_message

--- a/test/unit/krane/resource_deployer_test.rb
+++ b/test/unit/krane/resource_deployer_test.rb
@@ -7,18 +7,18 @@ class ResourceDeployerTest < Krane::TestCase
     whitelist_kind = "fake_kind"
     resource = build_mock_resource
     Krane::Kubectl.any_instance.expects(:run).with do |*args|
-      args.include?("--prune-whitelist=#{whitelist_kind}")
+      args.include?("--prune-allowlist=#{whitelist_kind}")
     end.returns(["", "", stub(success?: true)])
-    resource_deployer(kubectl_times: 0, prune_whitelist: [whitelist_kind]).deploy!([resource], false, true)
+    resource_deployer(kubectl_times: 0, prune_allowlist: [whitelist_kind]).deploy!([resource], false, true)
   end
 
   def test_deploy_no_prune_doesnt_prune
     whitelist_kind = "fake_kind"
     resource = build_mock_resource
     Krane::Kubectl.any_instance.expects(:run).with do |*args|
-      !args.include?("--prune-whitelist=#{whitelist_kind}")
+      !args.include?("--prune-allowlist=#{whitelist_kind}")
     end.returns(["", "", stub(success?: true)])
-    resource_deployer(kubectl_times: 0, prune_whitelist: [whitelist_kind]).deploy!([resource], false, false)
+    resource_deployer(kubectl_times: 0, prune_allowlist: [whitelist_kind]).deploy!([resource], false, false)
   end
 
   def test_deploy_verify_false_message
@@ -84,13 +84,13 @@ class ResourceDeployerTest < Krane::TestCase
 
   private
 
-  def resource_deployer(kubectl_times: 1, prune_whitelist: [])
+  def resource_deployer(kubectl_times: 1, prune_allowlist: [])
     unless kubectl_times == 0
       runless = build_runless_kubectl
       Krane::Kubectl.expects(:new).returns(runless).times(kubectl_times)
     end
     @deployer = Krane::ResourceDeployer.new(current_sha: 'test-sha',
-      statsd_tags: [], task_config: task_config, prune_whitelist: prune_whitelist,
+      statsd_tags: [], task_config: task_config, prune_allowlist: prune_allowlist,
       global_timeout: 1, selector: nil)
   end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Closes #917 

**How is this accomplished?**
global search and replace all whitelist references and change to allowlist

**What could go wrong?**
From what I understand, `--prune-allowlist` is only available in 1.26+, so any clusters running older versions will not have access. This necessitates, at the very least, a minor version bump. I've added compatibility code so older k8s versions will still work with the old `--prune-whitelist` flag


**Note: Failing CI is due to flaky tests: I'm slowly rerunning them one-by-one to get 🟢**