### PR TITLE
Created new optional flag to skip dry run proccess during deploy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+# 3.4.1
+
+- Added flag `--skip-dry-run` to completely opt out of dry run validation. 
+
 # 3.4.0
 
 - Use `prune-allowlist` instead of `prune-whitelist` for 1.26+ clusters. Clusters running 1.25 or less will continue to use `--prune-whitelist`. [#940](https://github.com/Shopify/krane/pull/940)

--- a/lib/krane/cli/deploy_command.rb
+++ b/lib/krane/cli/deploy_command.rb
@@ -33,6 +33,7 @@ module Krane
                                   default: false },
         "verify-result" => { type: :boolean, default: true,
                              desc: "Verify workloads correctly deployed" },
+        "skip-dry-run" => { type: :boolean, desc: "Enable skipping dry run", default: false},
       }
 
       def self.from_options(namespace, context, options)
@@ -71,6 +72,7 @@ module Krane
             selector: selector,
             selector_as_filter: selector_as_filter,
             protected_namespaces: protected_namespaces,
+            skip_dry_run: options["skip-dry-run"]
           )
 
           deploy.run!(

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.4.0"
+  VERSION = "3.4.1"
 end

--- a/test/exe/deploy_test.rb
+++ b/test/exe/deploy_test.rb
@@ -164,6 +164,7 @@ class DeployTest < Krane::TestCase
         selector: nil,
         selector_as_filter: false,
         protected_namespaces: ["default", "kube-system", "kube-public"],
+        skip_dry_run: false,
       }.merge(new_args),
       run_args: {
         verify_result: true,

--- a/test/helpers/fixture_deploy_helper.rb
+++ b/test/helpers/fixture_deploy_helper.rb
@@ -87,7 +87,7 @@ module FixtureDeployHelper
     success
   end
 
-  def deploy_dirs_without_profiling(dirs, wait: true, prune: true, bindings: {},
+  def deploy_dirs_without_profiling(dirs, wait: true, prune: true, skip_dry_run: false, bindings: {},
     sha: "k#{SecureRandom.hex(6)}", kubectl_instance: nil, global_timeout: nil,
     selector: nil, selector_as_filter: false,
     protected_namespaces: nil, render_erb: false, context: KubeclientHelper::TEST_CONTEXT)
@@ -105,7 +105,8 @@ module FixtureDeployHelper
       selector: selector,
       selector_as_filter: selector_as_filter,
       protected_namespaces: protected_namespaces,
-      render_erb: render_erb
+      render_erb: render_erb,
+      skip_dry_run: skip_dry_run
     )
     deploy.run(
       verify_result: wait,

--- a/test/integration-serial/serial_deploy_test.rb
+++ b/test/integration-serial/serial_deploy_test.rb
@@ -546,6 +546,17 @@ class SerialDeployTest < Krane::IntegrationTest
     ], in_order: true)
   end
 
+  def test_skip_dry_run_apply_success
+    Krane::KubernetesResource.any_instance.expects(:validate_definition).with { |params| params[:dry_run] == false }
+    Krane::ResourceDeployer.any_instance.expects(:dry_run).never
+    result = deploy_fixtures("hello-cloud", subset: %w(secret.yml), skip_dry_run: true)
+    assert_deploy_success(result)
+    assert_logs_match_all([
+      "Result: SUCCESS",
+      "Successfully deployed 1 resource",
+    ], in_order: true)
+  end
+
   private
 
   def rollout_conditions_annotation_key


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Add an optional field to skip the dry run process further down the deploy pipeline.

**How is this accomplished?**
Added the field in the deployment task command to be picked up and passed along. Also included a test to validate this behavior through verifying we do not call dry run if this flag is set to true. 

**What could go wrong?**
Nothing should, it's an optional flag that changes minimal behavior. 