### PR TITLE
smaller batch dry run blast

### DIFF
--- a/lib/krane/resource_deployer.rb
+++ b/lib/krane/resource_deployer.rb
@@ -163,7 +163,6 @@ module Krane
         global_mode = resources.all?(&:global?)
         out, err, st = kubectl.run(*command, log_failure: false, output_is_sensitive: output_is_sensitive,
           attempts: 2, use_namespace: !global_mode)
-
         tags = statsd_tags + (dry_run ? ['dry_run:true'] : ['dry_run:false'])
         Krane::StatsD.client.distribution('apply_all.duration', Krane::StatsD.duration(start), tags: tags)
         if st.success?


### PR DESCRIPTION
Replaces #943 

- Shrinks down the size of the batched apply set (to a tiny amount, in reality)
- All other kubectl validation is done client side and should be very fast. If necessary let's try to batch the client side validations, but that requires a big refactor