### PR TITLE
Version 3.5.0 - Start testing against k8s 1.28, drop support for k8s 1.23

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,24 +16,24 @@ jobs:
           - "3.0.4"
           - "2.7.6"
         kubernetes_version:
+          - "1.28.0"
           - "1.27.3"
           - "1.26.4"
           - "1.24.13"
-          - "1.23.17"
         test_suite:
           - "unit_test"
           - "cli_test"
           - "serial_integration_test"
           - "integration_test"
         include:
+          - kubernetes_version: "1.28.0"
+            kind_image: "kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213"
           - kubernetes_version: "1.27.3"
             kind_image: "kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
           - kubernetes_version: "1.26.4"
             kind_image: "kindest/node:v1.26.4@sha256:a539833d26264444ab3b8f5e56e23fa3361436445fa23c864e6dec622458858f"
           - kubernetes_version: "1.24.13"
             kind_image: "kindest/node:v1.24.13@sha256:c9e00e2b228e47ba3c96eaf0309b27dc3f73e444944e4c900016fd07b1b805cb"
-          - kubernetes_version: "1.23.17"
-            kind_image: "kindest/node:v1.23.17@sha256:eb33093b461ffee7614ca65a39ac0fb57982e1407dc38df4df92811c4fbcb687"
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## next
 
+# 3.5.0
+
+- Test against k8s 1.28
+- Drop support for k8s 1.23
+
 # 3.4.2
 
 - Remove flag `--skip-dry-run` (see [#946](https://github.com/Shopify/krane/pull/946))

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ If you need the ability to render dynamic values in templates before deploying, 
 ## Prerequisites
 
 * Ruby 2.7+
-* Your cluster must be running Kubernetes v1.22.0 or higher<sup>1</sup>
+* Your cluster must be running Kubernetes v1.24.0 or higher<sup>1</sup>
 
 ## Compatibility
 
@@ -89,11 +89,12 @@ Krane provides support for official upstream supported versions [Kubernetes](htt
 |        1.20        | No                |                  2.4.9                   |
 |        1.21        | No                |                  2.4.9                   |
 |        1.22        | No                |                  3.0.1                   |
-|        1.23        | Yes               |                    --                    |
+|        1.23        | No                |                  3.4.2                   |
 |        1.24        | Yes               |                    --                    |
 |        1.25        | No                |                    --                    |
 |        1.26        | Yes               |                    --                    |
 |        1.27        | Yes               |                    --                    |
+|        1.28        | Yes               |                    --                    |
 
 ## Installation
 

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.4.2"
+  VERSION = "3.5.0"
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Start testing against k8s 1.28, drop support for k8s 1.23
