### PR TITLE
disables parallel integration tests to see if that fixes flaky tests

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -35,6 +35,6 @@ Rake::TestTask.new(:cli_test) do |t|
 end
 
 desc("Run all tests")
-task(test: %w(unit_test serial_integration_test integration_test cli_test))
+task(test: %w(unit_test serial_integration_test cli_test))
 
 task(default: :test)


### PR DESCRIPTION
This is just a test. the parallel mode of integration test is extremely flaky even on local "dev env". 

**What are you trying to accomplish with this PR?**
Test for flaky tests

**How is this accomplished?**
disables parallel integration tests in CI

**What could go wrong?**
tbd
