### PR TITLE
fix tests to run locally and in CI and misc fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push]
 jobs:
   ruby-tests:
     runs-on: ubuntu-latest
+    env:
+      CI: true
 
     name: "Tests (${{matrix.test_suite}}) - Ruby ${{ matrix.ruby }} with Kubernetes ${{ matrix.kubernetes_version }}"
     strategy:

--- a/test/integration/krane_deploy_test.rb
+++ b/test/integration/krane_deploy_test.rb
@@ -449,7 +449,7 @@ class KraneDeployTest < Krane::IntegrationTest
     assert_logs_match_all([
       "Failed to deploy 1 priority resource",
       "Pod status: Failed.",
-      "no such file or directory",
+      *("no such file or directory" if ENV['CI'] == 'true'),
     ], in_order: true)
   end
 
@@ -508,7 +508,9 @@ class KraneDeployTest < Krane::IntegrationTest
       "Logs from container 'successful-init'",
       "Log from successful init container",
     ], in_order: true)
-    assert_logs_match("no such file or directory")
+    if ENV['CI'] == 'true'
+      assert_logs_match("no such file or directory")
+    end
   end
 
   def test_wait_false_still_waits_for_priority_resources
@@ -701,7 +703,10 @@ class KraneDeployTest < Krane::IntegrationTest
       %r{Deployment/bad-probe: TIMED OUT \(progress deadline: \d+s\)},
       "Timeout reason: ProgressDeadlineExceeded",
     ]
-    end_bad_probe_logs = ["Scaled up replica set bad-probe-"] # event
+
+    end_bad_probe_logs = [
+          *("Scaled up replica set bad-probe-" if ENV['CI'] == 'true') #event
+    ]
 
     # Debug info for bad probe timeout
     assert_logs_match_all(start_bad_probe_logs + [
@@ -719,7 +724,7 @@ class KraneDeployTest < Krane::IntegrationTest
       "Timeout reason: ProgressDeadlineExceeded",
       /Latest ReplicaSet: missing-volumes-\w+/,
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
-      /FailedMount.*secrets? "catphotoscom" not found/, # event
+      *(%r{/FailedMount.*secrets? "catphotoscom" not found/} if ENV['CI'] == 'true'), #event
     ], in_order: true)
 
     # Debug info for failure
@@ -729,7 +734,7 @@ class KraneDeployTest < Krane::IntegrationTest
       "The following containers are in a state that is unlikely to be recoverable:",
       "init-crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
       "Final status: 1 replica, 1 updatedReplica, 1 unavailableReplica",
-      "Scaled up replica set init-crash-", # event
+      *("Scaled up replica set init-crash-" if ENV['CI'] == 'true'),
       "this is a log from the crashing init container",
     ], in_order: true)
 
@@ -1113,8 +1118,8 @@ class KraneDeployTest < Krane::IntegrationTest
       "DaemonSet/crash-loop: FAILED",
       "crash-loop-back-off: Crashing repeatedly (exit 1). See logs for more information.",
       "Final status: #{num_ds} updatedNumberScheduled, #{num_ds} desiredNumberScheduled, 0 numberReady",
-      "Events (common success events excluded):",
-      "BackOff: Back-off restarting failed container",
+      *("Events (common success events excluded):" if ENV['CI'] == 'true'),
+      *("BackOff: Back-off restarting failed container" if ENV['CI'] == 'true'),
       "Logs from container 'crash-loop-back-off':",
       "this is a log from the crashing container",
     ], in_order: true)
@@ -1134,8 +1139,8 @@ class KraneDeployTest < Krane::IntegrationTest
       "Successfully deployed 1 resource and failed to deploy 1 resource",
       "StatefulSet/stateful-busybox: FAILED",
       "app: Crashing repeatedly (exit 1). See logs for more information.",
-      "Events (common success events excluded):",
-      %r{\[Pod/stateful-busybox-\d\]\tBackOff: Back-off restarting failed container},
+      *("Events (common success events excluded):" if ENV['CI'] == 'true'), # event
+      *(%r{\[Pod/stateful-busybox-\d\]\tBackOff: Back-off restarting failed container} if ENV['CI'] == 'true'),
       "Logs from container 'app':",
       "ls: /not-a-dir: No such file or directory",
     ], in_order: true)
@@ -1182,7 +1187,7 @@ class KraneDeployTest < Krane::IntegrationTest
       "ResourceQuota/resource-quotas",
       %r{Deployment/web: TIMED OUT \(progress deadline: \d+s\)},
       "Timeout reason: ProgressDeadlineExceeded",
-      "failed quota: resource-quotas", # from an event
+      *("failed quota: resource-quotas" if ENV['CI'] == 'true'), # from an event
     ], in_order: true)
 
     rqs = kubeclient.get_resource_quotas(namespace: @namespace)
@@ -1330,7 +1335,7 @@ class KraneDeployTest < Krane::IntegrationTest
       "Result: FAILURE",
       "Job/hello-job: FAILED",
       "Final status: Failed",
-      %r{\[Job/hello-job\]\tDeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)},
+      *(%r{\[Job/hello-job\]\tDeadlineExceeded: Job was active longer than specified deadline \(\d+ events\)} if ENV['CI'] == 'true'),
     ])
   end
 

--- a/test/integration/restart_task_test.rb
+++ b/test/integration/restart_task_test.rb
@@ -60,7 +60,7 @@ class RestartTaskTest < Krane::IntegrationTest
       "Waiting for rollout",
       "Result: SUCCESS",
       "Successfully restarted 1 resource",
-      %r{StatefulSet/stateful-busybox.* 2 replicas},
+      %r{StatefulSet/stateful-busybox.* (2 replicas|1 replica, 1 currentReplica)},
     ],
       in_order: true)
   end
@@ -291,7 +291,7 @@ class RestartTaskTest < Krane::IntegrationTest
       "The following containers have not passed their readiness probes",
       "app must exit 0 from the following command",
       "Final status: 2 replicas, 1 updatedReplica, 1 availableReplica, 1 unavailableReplica",
-      "Unhealthy: Readiness probe failed",
+      *("Unhealthy: Readiness probe failed" if ENV['CI'] == 'true'),
     ],
       in_order: true)
   end


### PR DESCRIPTION
1. Events aren't available when running tests locally in kind via `dev test integration_test`
2. k8s now shows "currentReplicas" separately
