### PR TITLE
Fix bug in RestartAPIError

### DIFF
--- a/lib/krane/restart_task.rb
+++ b/lib/krane/restart_task.rb
@@ -12,10 +12,9 @@ module Krane
     class FatalRestartError < FatalDeploymentError; end
 
     class RestartAPIError < FatalRestartError
-      def initialize(deployment_name, response)
+      def initialize(deployment_name, message)
         super("Failed to restart #{deployment_name}. " \
-            "API returned non-200 response code (#{response.code})\n" \
-            "Response:\n#{response.body}")
+            "Error:\n#{message}")
       end
     end
 


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Fix a minor bug in the `RestartAPIError` class, introduced in https://github.com/Shopify/krane/pull/284.  All the calls to `RestartAPIError.new` were changed to pass an error message instead of an HTTP response, but the `initialize` method itself wasn't adjusted accordingly.  The result looks like this:
```
/root/local/ruby-3.2.1/lib/ruby/gems/3.2.0/gems/krane-3.5.1/lib/krane/restart_task.rb:17:in `initialize': undefined method `code' for "Timed out connecting to server":String (NoMethodError)
            "API returned non-200 response code (#{response.code})\n" \
```

**How is this accomplished?**
Simply print the supplied error message instead of trying to parse an HTTP response.

**What could go wrong?**
Still printing the wrong thing would be the most severe consequence.
