### PR TITLE
 Start testing against k8s `1.{29,30}`, drop support for k8s `1.24`. Bumping version to `3.6.0`.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,24 +18,27 @@ jobs:
           - "3.0.4"
           - "2.7.6"
         kubernetes_version:
+          - "1.30.0"
+          - "1.29.4"
           - "1.28.0"
           - "1.27.3"
           - "1.26.4"
-          - "1.24.13"
         test_suite:
           - "unit_test"
           - "cli_test"
           - "serial_integration_test"
           - "integration_test"
         include:
+          - kubernetes_version: "1.30.0"
+            kind_image: "kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e"
+          - kubernetes_version: "1.29.4"
+            kind_image: "kindest/node:v1.29.4@sha256:3abb816a5b1061fb15c6e9e60856ec40d56b7b52bcea5f5f1350bc6e2320b6f8"
           - kubernetes_version: "1.28.0"
             kind_image: "kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213"
           - kubernetes_version: "1.27.3"
             kind_image: "kindest/node:v1.27.3@sha256:9dd3392d79af1b084671b05bcf65b21de476256ad1dcc853d9f3b10b4ac52dde"
           - kubernetes_version: "1.26.4"
             kind_image: "kindest/node:v1.26.4@sha256:a539833d26264444ab3b8f5e56e23fa3361436445fa23c864e6dec622458858f"
-          - kubernetes_version: "1.24.13"
-            kind_image: "kindest/node:v1.24.13@sha256:c9e00e2b228e47ba3c96eaf0309b27dc3f73e444944e4c900016fd07b1b805cb"
 
     steps:
       - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## next
 
+## 3.6.0
+
+- Test against k8s 1.29, 1.30
+- Drop support for k8s 1.24
+
 ## 3.5.3
 
 - Fix a minor bug in the RestartAPIError class (https://github.com/Shopify/krane/pull/953)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ This gem uses subclasses of `KubernetesResource` to implement custom success/fai
 
 If you work for Shopify, just run `dev up`, but otherwise:
 
-1. [Install kubectl version 1.22.0 or higher](https://kubernetes.io/docs/user-guide/prereqs/) and make sure it is in your path
+1. [Install kubectl version 1.28.0 or higher](https://kubernetes.io/docs/user-guide/prereqs/) and make sure it is in your path
 2. [Install minikube](https://kubernetes.io/docs/getting-started-guides/minikube/#installation) (required to run the test suite)
 3. [Install any required minikube drivers](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md) (on OS X, you may need the [hyperkit driver](https://github.com/kubernetes/minikube/blob/master/docs/drivers.md#hyperkit-driver)
 4. Check out the repo

--- a/README.md
+++ b/README.md
@@ -90,15 +90,17 @@ Krane provides support for official upstream supported versions [Kubernetes](htt
 |        1.21        | No                |                  2.4.9                   |
 |        1.22        | No                |                  3.0.1                   |
 |        1.23        | No                |                  3.4.2                   |
-|        1.24        | Yes               |                    --                    |
+|        1.24        | No                |                  3.5.3                   |
 |        1.25        | No                |                    --                    |
 |        1.26        | Yes               |                    --                    |
 |        1.27        | Yes               |                    --                    |
 |        1.28        | Yes               |                    --                    |
+|        1.29        | Yes               |                    --                    |
+|        1.30        | Yes               |                    --                    |
 
 ## Installation
 
-1. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl) (requires v1.22.0 or higher) and make sure it is available in your $PATH
+1. [Install kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/#install-kubectl-binary-via-curl) (requires v1.28.0 or higher) and make sure it is available in your $PATH
 2. Set up your [kubeconfig file](https://kubernetes.io/docs/tasks/access-application-cluster/authenticate-across-clusters-kubeconfig/) for access to your cluster(s).
 3. `gem install krane`
 

--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@ up:
   - podman
   - kind:
       name: krane
-      image: kindest/node:v1.26.4@sha256:354b7b57f16dc42d5ccc8c7eb3c3c8b3818531d35bc82600ba874a85fa1fa28a
+      image: kindest/node:v1.28.0@sha256:dad5a6238c5e41d7cac405fae3b5eda2ad1de6f1190fa8bfc64ff5bb86173213
 commands:
   test:
     run: bin/test

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.5.3"
+  VERSION = "3.6.0"
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Start testing against k8s 1.29 & 1.30, drop support for k8s 1.24.
Updating docs/default kind cluster to point to 1.28 as the "current" version. 