### PR TITLE
fix error with resource discovery when the api-paths are not at the root

### DIFF
--- a/lib/krane/cluster_resource_discovery.rb
+++ b/lib/krane/cluster_resource_discovery.rb
@@ -64,7 +64,7 @@ module Krane
 
     def fetch_api_path(path)
       @api_path_cache[path] ||= begin
-        raw_json, err, st = kubectl.run("get", "--raw", path, attempts: 2, use_namespace: false)
+        raw_json, err, st = kubectl.run("get", "--raw", base_api_path , attempts: 2, use_namespace: false)
         if st.success?
           MultiJson.load(raw_json)
         else


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
fix https://github.com/Shopify/krane/issues/892

**How is this accomplished?**
`kubectl.run("get", "--raw", path, attempts: 2, use_namespace: false)` in resource-discovery is using statich `/` as path which breaks when `api_paths` are not at the root level.
There is already a dynamic discovery for `base_api_path`, so using that similar to `api_path_cache` fixes the error.

**What could go wrong?**
- maybe wrong paths being discovered ?
