### PR TITLE
Add new annotation `krane.shopify.io/skip-endpoint-validation` to skip the validation of service endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+*Features*
+
+- Enable the option to bypass endpoint validation for a service by using the annotation `krane.shopify.io/skip-endpoint-validation: true`. 
+
 ## 3.6.0
 
 - Test against k8s 1.29, 1.30

--- a/lib/krane/kubernetes_resource/service.rb
+++ b/lib/krane/kubernetes_resource/service.rb
@@ -5,6 +5,7 @@ module Krane
   class Service < KubernetesResource
     TIMEOUT = 7.minutes
     SYNC_DEPENDENCIES = %w(Pod Deployment StatefulSet)
+    SKIP_ENDPOINT_VALIDATION_ANNOTATION = 'skip-endpoint-validation'
 
     def sync(cache)
       super
@@ -59,6 +60,9 @@ module Krane
     end
 
     def requires_endpoints?
+      # skip validation if the annotation is present
+      return false if skip_endpoint_validation
+
       # services of type External don't have endpoints
       return false if external_name_svc?
 
@@ -95,6 +99,10 @@ module Krane
 
     def published?
       @instance_data.dig('status', 'loadBalancer', 'ingress').present?
+    end
+
+    def skip_endpoint_validation
+      krane_annotation_value(SKIP_ENDPOINT_VALIDATION_ANNOTATION) == 'true'
     end
   end
 end

--- a/test/fixtures/for_unit_tests/service_test.yml
+++ b/test/fixtures/for_unit_tests/service_test.yml
@@ -215,3 +215,13 @@ spec:
   type: LoadBalancer
   selector:
     type: standard
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: standard-with-skip-endpoint-validation-annotation
+  annotations:
+    krane.shopify.io/skip-endpoint-validation: 'true'
+spec:
+  selector:
+    type: standard

--- a/test/unit/krane/kubernetes_resource/service_test.rb
+++ b/test/unit/krane/kubernetes_resource/service_test.rb
@@ -189,6 +189,21 @@ class ServiceTest < Krane::TestCase
     assert_equal("Selects at least 1 pod", svc.status)
   end
 
+  def test_service_with_skip_endpoint_validation_annotation_does_not_require_endpoints
+    svc_def = service_fixture('standard-with-skip-endpoint-validation-annotation')
+    svc = build_service(svc_def)
+
+    stub_kind_get("Service", items: [svc_def])
+    stub_kind_get("Deployment", items: deployment_fixtures)
+    stub_kind_get("Pod", items: [])
+    stub_kind_get("StatefulSet", items: [])
+    svc.sync(build_resource_cache)
+
+    assert(svc.exists?)
+    assert(svc.deploy_succeeded?)
+    assert_equal("Doesn't require any endpoints", svc.status)
+  end
+
   private
 
   def build_service(definition)


### PR DESCRIPTION
Introduce an annotation `krane.shopify.io/skip-endpoint-validation` to allow the deployment of services without endpoint validation when zero endpoints are expected.

**What are you trying to accomplish with this PR?**
In certain scenarios, we need to deploy services without any endpoints. Therefore, it is necessary to have a mechanism to bypass endpoint validation when zero endpoints are expected.

For instance, consider a Service associated with DaemonSet pods. If this DaemonSet is intended for a specific type of node that is not yet available, it is expected that there will be no pods from this DaemonSet, and consequently, no endpoints for the Service.

**How is this accomplished?**
The proposed change involves adding a new annotation `krane.shopify.io/skip-endpoint-validation` to bypass the validation of service endpoints.

**What could go wrong?**
The change is a minor improvement, and no significant risks have been identified.
