### PR TITLE
Rename `Splunk` to `Observe`

### DIFF
--- a/lib/krane/kubernetes_resource.rb
+++ b/lib/krane/kubernetes_resource.rb
@@ -25,7 +25,7 @@ module Krane
     DISABLE_FETCHING_EVENT_INFO = 'DISABLE_FETCHING_EVENT_INFO'
     DISABLED_LOG_INFO_MESSAGE = "collection is disabled by the #{DISABLE_FETCHING_LOG_INFO} env var."
     DISABLED_EVENT_INFO_MESSAGE = "collection is disabled by the #{DISABLE_FETCHING_EVENT_INFO} env var."
-    DEBUG_RESOURCE_NOT_FOUND_MESSAGE = "None found. Please check your usual logging service (e.g. Splunk)."
+    DEBUG_RESOURCE_NOT_FOUND_MESSAGE = "None found. Please check your usual logging service (e.g. Observe)."
     UNUSUAL_FAILURE_MESSAGE = <<~MSG
       It is very unusual for this resource type to fail to deploy. Please try the deploy again.
       If that new deploy also fails, contact your cluster administrator.

--- a/test/unit/krane/kubernetes_resource_test.rb
+++ b/test/unit/krane/kubernetes_resource_test.rb
@@ -269,8 +269,8 @@ class KubernetesResourceTest < Krane::TestCase
     expected_message = <<~STRING
       DummyResource/test: FAILED
         - Final status: Exists
-        - Events: None found. Please check your usual logging service (e.g. Splunk).
-        - Logs: None found. Please check your usual logging service (e.g. Splunk).
+        - Events: None found. Please check your usual logging service (e.g. Observe).
+        - Logs: None found. Please check your usual logging service (e.g. Observe).
     STRING
     assert_equal(expected_message.strip, dummy.debug_message)
 
@@ -281,8 +281,8 @@ class KubernetesResourceTest < Krane::TestCase
       Something went wrong I guess
 
         - Final status: Exists
-        - Events: None found. Please check your usual logging service (e.g. Splunk).
-        - Logs: None found. Please check your usual logging service (e.g. Splunk).
+        - Events: None found. Please check your usual logging service (e.g. Observe).
+        - Logs: None found. Please check your usual logging service (e.g. Observe).
     STRING
     assert_equal(expected_message.strip, dummy.debug_message)
 
@@ -294,8 +294,8 @@ class KubernetesResourceTest < Krane::TestCase
       > Some container: boom!
 
         - Final status: Exists
-        - Events: None found. Please check your usual logging service (e.g. Splunk).
-        - Logs: None found. Please check your usual logging service (e.g. Splunk).
+        - Events: None found. Please check your usual logging service (e.g. Observe).
+        - Logs: None found. Please check your usual logging service (e.g. Observe).
     STRING
     assert_equal(expected_message.strip, dummy.debug_message)
   end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
Noticed this is referencing Splunk which is now legacy and not supposed to be used:
<img width="1076" alt="image" src="https://github.com/user-attachments/assets/d218955a-80ac-41a3-bd63-c5614879bbf1">

**How is this accomplished?**
Replace with Observe

**What could go wrong?**
...
