### PR TITLE
Test against Kubernetes v1.32 and 1.33

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           - "3.0.4"
           - "2.7.6"
         kubernetes_version:
+          - "1.33.1"
+          - "1.32.5"
           - "1.31.2"
           - "1.30.0"
           - "1.29.4"
@@ -30,6 +32,10 @@ jobs:
           - "serial_integration_test"
           - "integration_test"
         include:
+          - kubernetes_version: "1.33.1"
+            kind_image: "kindest/node:v1.33.1@sha256:050072256b9a903bd914c0b2866828150cb229cea0efe5892e2b644d5dd3b34f"
+          - kubernetes_version: "1.32.5"
+            kind_image: "kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d"
           - kubernetes_version: "1.31.2"
             kind_image: "kindest/node:v1.31.2@sha256:18fbefc20a7113353c7b75b5c869d7145a6abd6269154825872dc59c1329912e"
           - kubernetes_version: "1.30.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 3.7.3
+
+- Test against k8s 1.32 and 1.33
+
 ## 3.7.2
 
 - Explicitly convert `current_generation` and `observed_generation` values to integers using `.to_i` to ensure consistentency during comparison

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ Krane provides support for official upstream supported versions [Kubernetes](htt
 |        1.29        | Yes               |                    --                    |
 |        1.30        | Yes               |                    --                    |
 |        1.31        | Yes               |                    --                    |
+|        1.32        | Yes               |                    --                    |
+|        1.33        | Yes               |                    --                    |
 
 ## Installation
 

--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,7 @@ up:
   - podman
   - kind:
       name: krane
-      image: kindest/node:v1.31.2@sha256:18fbefc20a7113353c7b75b5c869d7145a6abd6269154825872dc59c1329912e
+      image: kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d
 commands:
   test:
     run: bin/test unit_test && bin/test cli_test && bin/test serial_integration_test && bin/test integration_test

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.7.2"
+  VERSION = "3.7.3"
 end


### PR DESCRIPTION
What are you trying to accomplish with this PR?
Test against k8s v1.32 and k8s 1.33

How is this accomplished?
This modifies ci.yml so that we start testing krane against Kubernetes v1.32 and 1.33.

What could go wrong?
CI fails

