### PR TITLE
Handle bad encoding in container log output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## next
 
+## 3.7.4
+
+- Handle bad encoding in container log output
+
 ## 3.7.3
 
 - Test against k8s 1.32 and 1.33

--- a/lib/krane/container_logs.rb
+++ b/lib/krane/container_logs.rb
@@ -55,7 +55,7 @@ module Krane
         "--tail=#{DEFAULT_LINE_LIMIT}"
       end
       out, _err, _st = kubectl.run(*cmd, log_failure: false)
-      out.split("\n")
+      out.encode('UTF-8', invalid: :replace, replace: '').split("\n")
     end
 
     def kubectl

--- a/lib/krane/version.rb
+++ b/lib/krane/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Krane
-  VERSION = "3.7.3"
+  VERSION = "3.7.4"
 end


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**

Fixing this error:

```
ArgumentError: invalid byte sequence in UTF-8
    lib/krane/container_logs.rb:58:in `split'
    lib/krane/container_logs.rb:58:in `fetch_latest'
    lib/krane/container_logs.rb:20:in `sync'
    lib/krane/remote_logs.rb:27:in `each'
    lib/krane/remote_logs.rb:27:in `sync'
    lib/krane/kubernetes_resource/pod.rb:36:in `sync'
    lib/krane/resource_watcher.rb:57:in `block in sync_resources'
    lib/krane/concurrency.rb:13:in `each'
    lib/krane/concurrency.rb:13:in `block (2 levels) in split_across_threads'
```

We should never fail to stream logs, this PR forces the output encoding to UTF-8 on a best effort basis.
